### PR TITLE
chore: use uv for faster pip compile

### DIFF
--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 {{ end }}
 {{- if .Computed.python }}
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load("@rules_uv//uv:pip.bzl", "pip_compile")
 {{ end}}
 
 {{- if .Scaffold.lint }}
@@ -41,9 +41,9 @@ js_library(
 {{- end }}
 
 {{ if .Computed.python }}
-compile_pip_requirements(
+pip_compile(
     name = "requirements",
-    requirements_in = "requirements.txt",
-    requirements_txt = "requirements_lock.txt",
+    requirements_in = "//:requirements.txt",
+    requirements_txt = "//:requirements_lock.txt",
 )
 {{- end }}

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -7,6 +7,7 @@ bazel_dep(name = "aspect_rules_ts", version = "2.4.0")
 {{- end}}
 {{- if .Computed.python }}
 bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "rules_uv", version = "0.7.0")
 bazel_dep(name = "aspect_rules_py", version = "0.7.3")
 {{- end }}
 


### PR DESCRIPTION
---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Now uses https://github.com/theoremlp/rules_uv to run https://github.com/astral-sh/uv for `pip compile` to lock python requirements, reported to be 95% faster.

### Test plan

- Covered by existing test cases
