### PR TITLE
feat: include Python BUILD file generation

### DIFF
--- a/{{ .ProjectSnake }}/.aspect/cli/config.yaml
+++ b/{{ .ProjectSnake }}/.aspect/cli/config.yaml
@@ -9,6 +9,9 @@ configure:
 {{- if .Scaffold.protobuf }}
     protobuf: true
 {{- end }}
+{{- if .Scaffold.python }}
+    python: true
+{{- end }}
 
 {{- if .Scaffold.lint }}
 lint:

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -1,4 +1,4 @@
-"Targets in the workspace root"
+"""Targets in the workspace root"""
 {{- if .Computed.javascript }}
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -41,6 +41,10 @@ js_library(
 {{- end }}
 
 {{ if .Computed.python }}
+# Set `aspect configure` to produce aspect_rules_py targets rather than rules_python
+# aspect:map_kind py_binary py_binary @aspect_rules_py//py:defs.bzl
+# aspect:map_kind py_library py_library @aspect_rules_py//py:defs.bzl
+# aspect:map_kind py_test py_test @aspect_rules_py//py:defs.bzl
 compile_pip_requirements(
     name = "requirements",
     requirements_in = "requirements.txt",


### PR DESCRIPTION

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

When including Python in the languages, sets up BUILD file generation with `aspect configure`

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Ran through it locally in a repo generated by `aspect init`