### PR TITLE
chore: remove requirements.txt

### DIFF
--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -43,7 +43,7 @@ js_library(
 {{ if .Computed.python }}
 compile_pip_requirements(
     name = "requirements",
-    requirements_in = "requirements.txt",
+    requirements_in = "pyproject.toml",
     requirements_txt = "requirements_lock.txt",
 )
 {{- end }}

--- a/{{ .ProjectSnake }}/pyproject.toml
+++ b/{{ .ProjectSnake }}/pyproject.toml
@@ -1,2 +1,13 @@
+[project]
+name = "{{ .ProjectSnake }}"
+classifiers = ["Private :: Do Not Upload"]
+version = "0"
+# An example unpinned dependency.
+# Note that pip-compile will ensure the resolved versions of
+# direct and indirect dependencies are pinned.
+# Therefore we only need to constrain versions when some ranges 
+# of dependency versions are not compatible.
+dependencies = ["protobuf"]
+
 # See https://docs.astral.sh/ruff/configuration/
 [tool.ruff]

--- a/{{ .ProjectSnake }}/requirements.txt
+++ b/{{ .ProjectSnake }}/requirements.txt
@@ -1,6 +1,0 @@
-# An example unpinned dependency.
-# Note that pip-compile will ensure the resolved versions of
-# direct and indirect dependencies are pinned.
-# Therefore we only need to constrain versions in this file when some ranges 
-# of dependency versions are not compatible.
-protobuf

--- a/{{ .ProjectSnake }}/requirements_lock.txt
+++ b/{{ .ProjectSnake }}/requirements_lock.txt
@@ -16,4 +16,4 @@ protobuf==5.26.0 \
     --hash=sha256:e184175276edc222e2d5e314a72521e10049938a9a4961fe4bea9b25d073c03f \
     --hash=sha256:efd4f5894c50bd76cbcfdd668cd941021333861ed0f441c78a83d8254a01cc9f \
     --hash=sha256:f9ecc8eb6f18037e0cbf43256db0325d4723f429bca7ef5cd358b7c29d65f628
-    # via -r requirements.txt
+    # via {{ .Project }} (pyproject.toml)


### PR DESCRIPTION
The pyproject.toml file can be the input to pip-compile, and removes one boilerplate file.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases