### PR TITLE
chore: finish setup of python gazelle

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -67,6 +67,7 @@ features:
     globs:
       - "*/requirements*.txt"
       - "*/pyproject.toml"
+      - "*/gazelle_python.yaml"
   - value: "{{ .Computed.go }}"
     globs:
       - "*/go.mod"

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -5,6 +5,9 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 {{- end }}
 {{- if .Computed.python }}
+load("@pip//:requirements.bzl", "all_whl_requirements")
+load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
+load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 {{- end }}
 {{- end }}
@@ -52,4 +55,24 @@ compile_pip_requirements(
     requirements_in = "pyproject.toml",
     requirements_txt = "requirements_lock.txt",
 )
+
+# Fetches metadata for python packages we depend on.
+modules_mapping(
+    name = "modules_map",
+    wheels = all_whl_requirements,
+)
+
+# Provide a mapping from an import to the installed package that provides it.
+# Needed to generate BUILD files for .py files.
+# This macro produces two targets:
+# - //:gazelle_python_manifest.update can be used with `bazel run`
+#   to recalculate the manifest
+# - //:gazelle_python_manifest.test is a test target ensuring that
+#   the manifest doesn't need to be updated
+gazelle_python_manifest(
+    name = "gazelle_python_manifest",
+    modules_mapping = ":modules_map",
+    pip_repository_name = "pip",
+)
+
 {{- end }}

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.0.0-rc1")
 {{- end }}
 {{- if .Computed.python }}
 bazel_dep(name = "rules_python", version = "0.33.0")
+bazel_dep(name = "rules_python_gazelle_plugin", version = "0.33.0")
 bazel_dep(name = "aspect_rules_py", version = "0.7.3")
 {{- end }}
 {{- if .Computed.go }}

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -40,13 +40,20 @@ This ensures you use the same pnpm version as other developers, and the lockfile
 After adding a new `import` statement in Python code, run these commands:
 
 ```shell
+# Update BUILD files to include the dependency
+% aspect configure
+```
+
+If the package is not already a dependency of the project, you'll have to do some additional steps:
+
+```shell
 # Update dependencies table to include your new dependency
 % vim pypyroject.toml
 # Update requirements_lock.txt to pin this dependency
 % aspect run requirements.update
 # Update gazelle_python.yaml to list the imports provided by this package
 % aspect run gazelle_python_manifest.update
-# Update BUILD files to include the dependency
+# Repeat
 % aspect configure
 ```
 
@@ -58,12 +65,17 @@ After adding a new `import` statement in Python code, run these commands:
 After adding a new `import` statement in Go code, run these commands:
 
 ```shell
+# Update BUILD file to include the dependency
+% aspect configure
+```
+
+If the package is not already a dependency of the project, you'll have to do some additional steps:
+
+```shell
 # Update go.mod and go.sum, using same Go SDK as Bazel
 % aspect run @rules_go//go -- mod tidy -v
 # Update MODULE.bazel to include the package in `use_repo`
 % aspect mod tidy
-# Update BUILD file to include package in `deps`
-% aspect configure
 ```
 
 {{- end }}

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -34,6 +34,24 @@ Similarly, you can run other `pnpm` commands to install or remove packages.
 This ensures you use the same pnpm version as other developers, and the lockfile format will stay constant.
 {{- end }}
 
+{{ if .Computed.python }}
+## Working with Python packages
+
+After adding a new `import` statement in Python code, run these commands:
+
+```shell
+# Update dependencies table to include your new dependency
+% vim pypyroject.toml
+# Update requirements_lock.txt to pin this dependency
+% aspect run requirements.update
+# Update gazelle_python.yaml to list the imports provided by this package
+% aspect run gazelle_python_manifest.update
+# Update BUILD files to include the dependency
+% aspect configure
+```
+
+{{- end }}
+
 {{ if .Computed.go }}
 ## Working with Go modules
 

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -37,7 +37,7 @@ This ensures you use the same pnpm version as other developers, and the lockfile
 {{ if .Computed.python }}
 ## Working with Python packages
 
-After adding a new `import` statement in Python code, run these commands:
+After adding a new `import` statement in Python code, run `aspect configure` to update the BUILD file.
 
 ```shell
 # Update BUILD files to include the dependency
@@ -62,12 +62,7 @@ If the package is not already a dependency of the project, you'll have to do som
 {{ if .Computed.go }}
 ## Working with Go modules
 
-After adding a new `import` statement in Go code, run these commands:
-
-```shell
-# Update BUILD file to include the dependency
-% aspect configure
-```
+After adding a new `import` statement in Go code, run `aspect configure` to update the BUILD file.
 
 If the package is not already a dependency of the project, you'll have to do some additional steps:
 
@@ -76,6 +71,8 @@ If the package is not already a dependency of the project, you'll have to do som
 % aspect run @rules_go//go -- mod tidy -v
 # Update MODULE.bazel to include the package in `use_repo`
 % aspect mod tidy
+# Repeat
+% aspect configure
 ```
 
 {{- end }}

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -39,11 +39,6 @@ This ensures you use the same pnpm version as other developers, and the lockfile
 
 After adding a new `import` statement in Python code, run `aspect configure` to update the BUILD file.
 
-```shell
-# Update BUILD files to include the dependency
-% aspect configure
-```
-
 If the package is not already a dependency of the project, you'll have to do some additional steps:
 
 ```shell

--- a/{{ .ProjectSnake }}/gazelle_python.yaml
+++ b/{{ .ProjectSnake }}/gazelle_python.yaml
@@ -1,0 +1,57 @@
+# GENERATED FILE - DO NOT EDIT!
+#
+# To update this file, run:
+#   bazel run //:gazelle_python_manifest.update
+
+manifest:
+  modules_mapping:
+    google.protobuf: protobuf
+    google.protobuf.any_pb2: protobuf
+    google.protobuf.api_pb2: protobuf
+    google.protobuf.compiler: protobuf
+    google.protobuf.compiler.plugin_pb2: protobuf
+    google.protobuf.descriptor: protobuf
+    google.protobuf.descriptor_database: protobuf
+    google.protobuf.descriptor_pb2: protobuf
+    google.protobuf.descriptor_pool: protobuf
+    google.protobuf.duration_pb2: protobuf
+    google.protobuf.empty_pb2: protobuf
+    google.protobuf.field_mask_pb2: protobuf
+    google.protobuf.internal: protobuf
+    google.protobuf.internal.api_implementation: protobuf
+    google.protobuf.internal.builder: protobuf
+    google.protobuf.internal.containers: protobuf
+    google.protobuf.internal.decoder: protobuf
+    google.protobuf.internal.encoder: protobuf
+    google.protobuf.internal.enum_type_wrapper: protobuf
+    google.protobuf.internal.extension_dict: protobuf
+    google.protobuf.internal.field_mask: protobuf
+    google.protobuf.internal.message_listener: protobuf
+    google.protobuf.internal.python_edition_defaults: protobuf
+    google.protobuf.internal.python_message: protobuf
+    google.protobuf.internal.testing_refleaks: protobuf
+    google.protobuf.internal.type_checkers: protobuf
+    google.protobuf.internal.well_known_types: protobuf
+    google.protobuf.internal.wire_format: protobuf
+    google.protobuf.json_format: protobuf
+    google.protobuf.message: protobuf
+    google.protobuf.message_factory: protobuf
+    google.protobuf.proto_builder: protobuf
+    google.protobuf.pyext: protobuf
+    google.protobuf.pyext.cpp_message: protobuf
+    google.protobuf.reflection: protobuf
+    google.protobuf.service: protobuf
+    google.protobuf.service_reflection: protobuf
+    google.protobuf.source_context_pb2: protobuf
+    google.protobuf.struct_pb2: protobuf
+    google.protobuf.symbol_database: protobuf
+    google.protobuf.testdata: protobuf
+    google.protobuf.text_encoding: protobuf
+    google.protobuf.text_format: protobuf
+    google.protobuf.timestamp_pb2: protobuf
+    google.protobuf.type_pb2: protobuf
+    google.protobuf.unknown_fields: protobuf
+    google.protobuf.util: protobuf
+    google.protobuf.wrappers_pb2: protobuf
+  pip_repository:
+    name: pip


### PR DESCRIPTION
It requires a manifest file to lookup import statements to 3p packages

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Python projects now support third-party packages in `configure` without needing a manual `resolve` directive.

### Test plan

- Covered by existing test cases
