### PR TITLE
chore: enable buildifier formatting check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,15 +31,23 @@ jobs:
                 scaffold new --preset=${{ matrix.preset }} --no-prompt $GITHUB_WORKSPACE
                 cd scaffold_test*
                 git init
+                git add .
+                git config user.email "noreply@aspect.build"
+                git config user.name "No One"
+                git commit -a -m "initial commit"
                 echo "::set-output name=dir::$PWD"
 
             - run: bazel test ...
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               
-            - run: bazel run //tools/format:format.check
+            - run: bazel run format
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               if: "${{ matrix.preset != 'minimal' }}"
 
+            - name: format made no changes
+              working-directory: "${{ steps.scaffold.outputs.dir }}"
+              run: git diff --exit-code
+              
             - run: bazel run @rules_go//go mod tidy
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               if: "${{ matrix.preset == 'go' }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
             - run: bazel test ...
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               
-            - run: bazel run format
+            - run: bazel run //tools/format:format.check
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               if: "${{ matrix.preset != 'minimal' }}"
 

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -1,8 +1,13 @@
-"""Targets in the workspace root"""{{ if or .Computed.javascript .Computed.python }}
+"""Targets in the workspace root"""
+{{- if or .Computed.javascript .Computed.python }}
 {{ if .Computed.javascript }}
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@npm//:defs.bzl", "npm_link_all_packages"){{ end }}{{ if .Computed.python }}
-load("@rules_python//python:pip.bzl", "compile_pip_requirements"){{ end }}{{ end }}
+load("@npm//:defs.bzl", "npm_link_all_packages")
+{{- end }}
+{{- if .Computed.python }}
+load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+{{- end }}
+{{- end }}
 {{- if .Scaffold.lint }}
 
 alias(

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -1,13 +1,10 @@
-"""Targets in the workspace root"""
-{{- if .Computed.javascript }}
+"""Targets in the workspace root"""{{ if or .Computed.javascript .Computed.python }}
+{{ if .Computed.javascript }}
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-{{ end }}
-{{- if .Computed.python }}
-load("@rules_python//python:pip.bzl", "compile_pip_requirements")
-{{ end}}
-
+load("@npm//:defs.bzl", "npm_link_all_packages"){{ end }}{{ if .Computed.python }}
+load("@rules_python//python:pip.bzl", "compile_pip_requirements"){{ end }}{{ end }}
 {{- if .Scaffold.lint }}
+
 alias(
     name = "format",
     actual = "//tools/format",
@@ -20,27 +17,27 @@ exports_files(
         "pyproject.toml",
 {{- end }}
     ],
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
 )
 {{- end }}
-
 {{- if .Computed.javascript }}
-npm_link_all_packages(name = "node_modules")
 
+npm_link_all_packages(name = "node_modules")
 {{- if .Scaffold.lint }}
+
 js_library(
     name = "eslintrc",
     srcs = ["eslint.config.mjs"],
+    visibility = ["//:__subpackages__"],
     deps = [
         ":node_modules/@eslint/js",
         ":node_modules/typescript-eslint",
     ],
-    visibility = ["//:__subpackages__"],
 )
 {{- end }}
 {{- end }}
+{{- if .Computed.python }}
 
-{{ if .Computed.python }}
 # Set `aspect configure` to produce aspect_rules_py targets rather than rules_python
 # aspect:map_kind py_binary py_binary @aspect_rules_py//py:defs.bzl
 # aspect:map_kind py_library py_library @aspect_rules_py//py:defs.bzl

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -24,8 +24,8 @@ bazel_dep(name = "gazelle", version = "0.37.0")
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//tools:tools.lock.json")
 use_repo(multitool, "multitool")
-
 {{- if .Computed.go }}
+
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 
@@ -33,9 +33,10 @@ go_deps.from_file(go_mod = "//:go.mod")
 # Run 'bazel mod tidy' to update this
 use_repo(go_deps)
 {{- end }}
-
 {{- if .Computed.javascript }}
+
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
+
 # Allows developers to run the same pnpm version that Bazel manages
 use_repo(pnpm, "pnpm")
 
@@ -56,9 +57,10 @@ rules_ts_ext = use_extension(
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
 {{- end}}
-
 {{- if .Computed.python }}
+
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     python_version = "3.9",
@@ -66,12 +68,15 @@ python.toolchain(
 
 pip.parse(
     hub_name = "pip",
-    requirements_lock = "//:requirements_lock.txt",
     python_version = "3.9",
+    requirements_lock = "//:requirements_lock.txt",
 )
 use_repo(pip, "pip")
 {{- end }}
-
 {{- if .Scaffold.protobuf }}
-register_toolchains("//tools/toolchains:all", dev_dependency = True)
+
+register_toolchains(
+    "//tools/toolchains:all",
+    dev_dependency = True,
+)
 {{- end }}

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 {{- if .Scaffold.lint }}
 bazel_dep(name = "aspect_rules_lint", version = "1.0.0-rc3")
+bazel_dep(name = "buildifier_prebuilt", version = "6.3.3")
 {{- end }}
 {{- if .Scaffold.protobuf }}
 bazel_dep(name = "rules_proto", version = "6.0.0.bcr.1")

--- a/{{ .ProjectSnake }}/package.json
+++ b/{{ .ProjectSnake }}/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "{{ .Project }}",
-    "private": true,
-    "dependencies": {
-        "@bufbuild/protobuf": "^1"
-    },
-    "devDependencies": {
-        "@bufbuild/protoc-gen-es": "^1",
-        "@eslint/js": "^9",
-        "eslint": "^9",
-        "typescript-eslint": "^7",
-        "typescript": "5.4.5",
-        "prettier": "^3"
-    }
+  "name": "{{ .Project }}",
+  "private": true,
+  "dependencies": {
+    "@bufbuild/protobuf": "^1"
+  },
+  "devDependencies": {
+    "@bufbuild/protoc-gen-es": "^1",
+    "@eslint/js": "^9",
+    "eslint": "^9",
+    "typescript-eslint": "^7",
+    "typescript": "5.4.5",
+    "prettier": "^3"
+  }
 }

--- a/{{ .ProjectSnake }}/tools/format/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/format/BUILD.bazel
@@ -26,4 +26,5 @@ format_multirun(
 {{ if .Computed.javascript }}
     javascript = ":prettier",
 {{ end }}
+    starlark = "@buildifier_prebuilt//:buildifier",
 )

--- a/{{ .ProjectSnake }}/tools/format/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/format/BUILD.bazel
@@ -5,26 +5,26 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
-{{ if .Computed.javascript }}
+{{- if .Computed.javascript }}
 load("@npm//:prettier/package_json.bzl", prettier = "bin")
-{{ end }}
+{{- end }}
 
 package(default_visibility = ["//:__subpackages__"])
 
-{{ if .Computed.javascript }}
+{{ if .Computed.javascript -}}
 prettier.prettier_binary(
     name = "prettier",
     env = {"BAZEL_BINDIR": "."},
 )
-{{ end }}
 
+{{ end -}}
 format_multirun(
     name = "format",
-{{ if .Computed.go }}
+{{- if .Computed.go }}
     go = "@aspect_rules_lint//format:gofumpt",
-{{ end }}
-{{ if .Computed.javascript }}
+{{- end }}
+{{- if .Computed.javascript }}
     javascript = ":prettier",
-{{ end }}
+{{- end }}
     starlark = "@buildifier_prebuilt//:buildifier",
 )

--- a/{{ .ProjectSnake }}/tools/lint/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/lint/BUILD.bazel
@@ -3,14 +3,14 @@
 This is in its own package because it has so many loading-time symbols,
 we don't want to trigger eager fetches of these for builds that don't want to run format.
 """
-
 {{- if .Computed.javascript }}
+
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 {{- end }}
 
 package(default_visibility = ["//:__subpackages__"])
-
 {{- if .Computed.python }}
+
 alias(
     name = "ruff",
     actual = select({
@@ -21,7 +21,7 @@ alias(
     }),
 )
 {{- end }}
-
 {{- if .Computed.javascript }}
+
 eslint_bin.eslint_binary(name = "eslint")
 {{- end }}

--- a/{{ .ProjectSnake }}/tools/lint/linters.bzl
+++ b/{{ .ProjectSnake }}/tools/lint/linters.bzl
@@ -1,15 +1,15 @@
 "Define linter aspects"
 
-{{- if .Computed.javascript }}
+{{ if .Computed.javascript -}}
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
-{{- end }}
+{{ end -}}
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
-{{- if .Computed.python }}
+{{ if .Computed.python -}}
 load("@aspect_rules_lint//lint:ruff.bzl", "lint_ruff_aspect")
-{{- end }}
+{{ end -}}
 load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 
-{{- if .Computed.javascript }}
+{{ if .Computed.javascript -}}
 eslint = lint_eslint_aspect(
     binary = "@@//tools/lint:eslint",
     # We trust that eslint will locate the correct configuration file for a given source file.
@@ -21,9 +21,8 @@ eslint = lint_eslint_aspect(
 )
 
 eslint_test = lint_test(aspect = eslint)
-{{- end }}
-
-{{- if .Computed.python }}
+{{ end -}}
+{{ if .Computed.python -}}
 ruff = lint_ruff_aspect(
     binary = "@@//tools/lint:ruff",
     configs = [
@@ -33,8 +32,8 @@ ruff = lint_ruff_aspect(
 )
 
 ruff_test = lint_test(aspect = ruff)
-{{- end}}
 
+{{ end -}}
 shellcheck = lint_shellcheck_aspect(
     binary = "@multitool//tools/shellcheck",
     config = "@@//:.shellcheckrc",

--- a/{{ .ProjectSnake }}/tools/toolchains/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/toolchains/BUILD.bazel
@@ -1,7 +1,7 @@
-{{- if .Scaffold.protobuf }}
+{{ if .Scaffold.protobuf -}}
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
-{{- if .Computed.python }}
+{{ if .Computed.python -}}
 # Configure protoc to have the right arguments for generating Python stubs.
 proto_lang_toolchain(
     name = "protoc_py_toolchain",


### PR DESCRIPTION
It literally took me two hours to get all the hyphens in the right spots to make it remain formatted along every conditional path.

Note that I *could* update to a newer scaffold that has a "post" hook feature, but then every user will observe that format running after stamping it out, so this is better (even if really annoying)

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
