### PR TITLE
Add 'aspect run format' pre-commit hook.

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -52,6 +52,7 @@ features:
       - "*/tools/format/*"
       - "*/tools/lint/*"
       - "*/.shellcheckrc"
+      - "*/.pre-commit-config.yaml"
   - value: "{{ .Scaffold.stamp }}"
     globs:
       - "*/tools/workspace_status.sh"

--- a/{{ .ProjectSnake }}/.pre-commit-config.yaml
+++ b/{{ .ProjectSnake }}/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: format
+    name: Format
+    entry: aspect run //tools/format:format
+    language: system
+    types: [text]


### PR DESCRIPTION
The README.bazel.md that is currently generated mentions the ability to use pre-commit to format code automatically on git commit.

With these changes, a .pre-commit-config.yaml is now generated that configures an 'aspect run format' hook out-of-the-box when users opt into formatting/linting.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

When generating a new project with linting/formatting enabled, a .pre-commit-config.yaml is now written that configures an `aspect run format` pre-commit hook.


### Test plan

- Manual testing:

1. Run `aspect init`, opting into auto-formatting
2. Run `pre-commit install`
3. `git commit` any file subject to auto-formatting (e.g. `BUILD.bazel`)
4. Observe the aspect-format pre-commit hook run before the commit is accepted:
```
❯ git commit
aspect-format............................................................Passed
```