### PR TITLE
Configure ruff formatting for Python projects

### DIFF
--- a/{{ .ProjectSnake }}/tools/format/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/format/BUILD.bazel
@@ -26,5 +26,8 @@ format_multirun(
 {{- if .Computed.javascript }}
     javascript = ":prettier",
 {{- end }}
+{{- if .Computed.python }}
+    python = "//tools/lint:ruff",
+{{- end }}
     starlark = "@buildifier_prebuilt//:buildifier",
 )


### PR DESCRIPTION
Projects generated with support for Python and linting+formatting are now configured to format Python code out-of-the-box.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear above: yes


### Test plan

- Manual testing:

1. Generate a project opting into Python + formatting
2. `echo "'foo'" > foo.py`
3. `git init && git add .`
4. `bazel run //tools/format:format`
   * output should include `Formatted Python in 0m0.XYZs`
   * `git diff` should show that the single quotes in `foo.py` were changed to double quotes
