### PR TITLE
fix: restore blog version of multitool run

### DIFF
--- a/{{ .ProjectSnake }}/tools/_multitool_run_under_cwd.sh
+++ b/{{ .ProjectSnake }}/tools/_multitool_run_under_cwd.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 # See https://blog.aspect.build/run-tools-installed-by-bazel
-bazel run "@multitool//tools/$(basename "$0"):cwd" -- "$@"
+target="@multitool//tools/$(basename "$0")"
+# NB: we don't use 'bazel run' because it may leave behind zombie processes under ibazel
+bazel 2>/dev/null build "$target" && exec $(bazel info execution_root)/$(bazel 2>/dev/null cquery --output=files "$target") "$@"


### PR DESCRIPTION
Pointed out by Anduril

---

### Changes are visible to end-users: no

### Test plan

Trust our customer that the older incantation from our blog post is more correct