### PR TITLE
feat: add Rust support in 'aspect init'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,9 +82,9 @@ jobs:
 
             - name: Rust smoke test
               run: |
-                mkdir -p src
+                mkdir -p hello_world/src
 
-                cat >BUILD.bazel <<EOF
+                cat >hello_world/BUILD.bazel <<EOF
                 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
                 rust_binary(
@@ -93,11 +93,11 @@ jobs:
                 )
                 EOF
 
-                cat >src/main.rs <<EOF
+                cat >hello_world/src/main.rs <<EOF
                 fn main() { println!("Hello from Rust"); }
                 EOF
 
-                output="$(bazel run //:hello_world)"
+                output="$(bazel run //hello_world)"
                 [[ "${output}" == "Hello from Rust" ]] || { echo >&2 "Wanted output 'Hello from Rust' but got '${output}'" ; exit 1 ; }
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               if: "${{ matrix.preset == 'rust' }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,28 @@ jobs:
               working-directory: "${{ steps.scaffold.outputs.dir }}"
               if: "${{ matrix.preset == 'js' }}"
 
+            - name: Rust smoke test
+              run: |
+                mkdir -p src
+
+                cat >BUILD.bazel <<EOF
+                load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+                rust_binary(
+                    name = "hello_world",
+                    srcs = ["src/main.rs"],
+                )
+                EOF
+
+                cat >src/main.rs <<EOF
+                fn main() { println!("Hello from Rust"); }
+                EOF
+
+                output="$(bazel run //:hello_world)"
+                [[ "${output}" == "Hello from Rust" ]] || { echo >&2 "Wanted output 'Hello from Rust' but got '${output}'" ; exit 1 ; }
+              working-directory: "${{ steps.scaffold.outputs.dir }}"
+              if: "${{ matrix.preset == 'rust' }}"
+
             - run: bazel lint ...
               working-directory: "${{ steps.scaffold.outputs.dir }}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
                     - go
                     - py
                     - cpp
+                    - rust
                     - minimal
                 include:
                   # Aspect CLI prior to Sept 2024 used this version.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,6 @@ jobs:
                     - cpp
                     - rust
                     - minimal
-                include:
-                  # Aspect CLI prior to Sept 2024 used this version.
-                  # Preserve compat until we think everyone has upgraded.
-                  - scaffold-version: v0.0.99
-                    preset: kitchen-sink
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,11 @@ jobs:
                     - py
                     - cpp
                     - minimal
+                include:
+                  # Aspect CLI prior to Sept 2024 used this version.
+                  # Preserve compat until we think everyone has upgraded.
+                  - scaffold-version: v0.0.99
+                    preset: kitchen-sink
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -107,6 +107,7 @@ features:
   - value: "{{ .Computed.rust }}"
     globs:
       - "*/Cargo.toml"
+      - "*/tools/cargo"
       - "*/src/main.rs"
 
 computed:

--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -114,7 +114,7 @@ computed:
   go: "{{ has \"Go\" .Scaffold.langs }}"
   java: "{{ has \"Java\" .Scaffold.langs }}"
   cpp: "{{ has \"C & C++\" .Scaffold.langs }}"
-  rust: "{{ has "Rust" .Scaffold.langs }}"
+  rust: "{{ has \"Rust\" .Scaffold.langs }}"
 
 presets:
   kitchen-sink:

--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -32,6 +32,7 @@ questions:
         - Go
         - Java
         - C & C++
+        - Rust
   - name: copier
     prompt:
       confirm: Setup code generation?
@@ -103,7 +104,9 @@ features:
     globs:
       - "*/.aspect/cli/go_image.star"
       - "*/tools/oci/go_image.bzl"
-
+  - value: "{{ .Computed.rust }}"
+    globs:
+      - "*/Cargo.toml"
 
 computed:
   javascript: "{{ has \"JavaScript & TypeScript\" .Scaffold.langs }}"
@@ -111,11 +114,12 @@ computed:
   go: "{{ has \"Go\" .Scaffold.langs }}"
   java: "{{ has \"Java\" .Scaffold.langs }}"
   cpp: "{{ has \"C & C++\" .Scaffold.langs }}"
+  rust: "{{ has "Rust" .Scaffold.langs }}"
 
 presets:
   kitchen-sink:
     lint: true
-    langs: ['C & C++', 'JavaScript & TypeScript', 'Python', 'Go', 'Java']
+    langs: ['C & C++', 'JavaScript & TypeScript', 'Python', 'Go', 'Java', 'Rust']
     copier: true
     stamp: true
     protobuf: true
@@ -135,6 +139,9 @@ presets:
     lint: true
   cpp:
     langs: ['C & C++']
+    lint: true
+  rust:
+    langs: ['Rust']
     lint: true
   minimal:
     langs: []

--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -107,6 +107,7 @@ features:
   - value: "{{ .Computed.rust }}"
     globs:
       - "*/Cargo.toml"
+      - "*/src/main.rs"
 
 computed:
   javascript: "{{ has \"JavaScript & TypeScript\" .Scaffold.langs }}"

--- a/{{ .ProjectSnake }}/Cargo.toml
+++ b/{{ .ProjectSnake }}/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{ .ProjectPascal }}"
+name = "{{ .ProjectSnake }}"
 version = "0.1.0"
 edition = "2021"
 

--- a/{{ .ProjectSnake }}/Cargo.toml
+++ b/{{ .ProjectSnake }}/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "{{ .ProjectPascal }}"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "aspect_rules_py", version = "0.8.0")
 bazel_dep(name = "rules_uv", version = "0.31.0")
 {{- end }}
 {{- if .Computed.rust }}
-bazel_dep(name = "rules_rust", version = "0.45.1")
+bazel_dep(name = "rules_rust", version = "0.50.1")
 {{- end }}
 {{- if .Computed.go }}
 bazel_dep(name = "rules_go", version = "0.50.1")

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -22,6 +22,9 @@ bazel_dep(name = "rules_python_gazelle_plugin", version = "0.36.0")
 bazel_dep(name = "aspect_rules_py", version = "0.8.0")
 bazel_dep(name = "rules_uv", version = "0.31.0")
 {{- end }}
+{{- if .Computed.rust }}
+bazel_dep(name = "rules_rust", version = "0.45.1")
+{{- end }}
 {{- if .Computed.go }}
 bazel_dep(name = "rules_go", version = "0.50.1")
 bazel_dep(name = "gazelle", version = "0.39.0")
@@ -38,6 +41,8 @@ multitool.hub(lockfile = "//tools:tools.lock.json")
 use_repo(multitool, "multitool")
 {{- if .Computed.go }}
 
+#########################
+# Go
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 
@@ -47,6 +52,8 @@ use_repo(go_deps)
 {{- end }}
 {{- if .Computed.javascript }}
 
+#########################
+# JavaScript and pnpm package manager
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 
 # Allows developers to run the same pnpm version that Bazel manages
@@ -71,6 +78,8 @@ use_repo(rules_ts_ext, "npm_typescript")
 {{- end}}
 {{- if .Computed.python }}
 
+#########################
+# Hermetic Python interpreter and pip dependencies
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
@@ -93,9 +102,9 @@ register_toolchains(
 )
 {{- end }}
 {{- if .Computed.cpp }}
+
 #########################
 # Hermetic C++ toolchain, to relieve the dependency on a locally installed CC etc.
-
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     # NB: llvm doesn't release for all platforms on every patch release
@@ -109,7 +118,18 @@ use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain//:all")
 {{- end }}
+{{- if .Computed.rust }}
+
+#########################
+# Support for Rust, see https://github.com/bazelbuild/rules_rust
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2021",
+    versions = ["1.75.0"],
+)
+{{- end }}
 {{- if .Computed.java }}
+
 #########################
 # Java and other JVM languages:
 # https://github.com/bazelbuild/rules_jvm_external/blob/master/examples/bzlmod/MODULE.bazel
@@ -117,7 +137,6 @@ register_toolchains("@llvm_toolchain//:all")
 
 # In the Maven support variation, the dependencies are conveniently listed here
 # in the MODULE.bazel file.
-
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = ["io.grpc:grpc-all:1.51.1"],

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -115,3 +115,25 @@ Available keys are listed in `/tools/workspace_status.sh` and may include:
 
 To request stamped build outputs, add the flag `--config=release`.
 {{ end }}
+
+{{ if .Computed.rust }}
+## Working with Cargo
+
+If you need to run `cargo` outside of Bazel, you can do so by running `./tools/cargo`, e.g.
+
+```console
+% ./tools/cargo add reqwest
+    Updating crates.io index
+      Adding reqwest v0.12.7 to dependencies.
+             Features:
+             + __tls
+             + charset
+             + default-tls
+             + h2
+             + http2
+             + macos-system-configuration
+             25 deactivated features
+    Updating crates.io index
+```
+
+{{ end }}

--- a/{{ .ProjectSnake }}/src/main.rs
+++ b/{{ .ProjectSnake }}/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello!");
+}

--- a/{{ .ProjectSnake }}/src/main.rs
+++ b/{{ .ProjectSnake }}/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello!");
-}

--- a/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
+++ b/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
@@ -27,4 +27,4 @@ case "$(basename "$0")" in
 esac
 
 # NB: we don't use 'bazel run' because it may leave behind zombie processes under ibazel
-bazel 2>/dev/null build --build_runfile_links "$target" && BAZEL_BINDIR=. exec $(bazel info execution_root)/$(bazel 2>/dev/null cquery --output=files "$target") "$@"
+bazel 2>/dev/null build --build_runfile_links "$target" && BAZEL_BINDIR=. exec $(bazel 2>/dev/null info execution_root)/$(bazel 2>/dev/null cquery --output=files "$target") "$@"

--- a/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
+++ b/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
@@ -9,6 +9,10 @@ case "$(basename "$0")" in
     target="//tools:copier"
     ;;
 {{- end }}
+  cargo)
+    # Being documented in https://github.com/bazelbuild/rules_rust/pull/2890
+    target="@rules_rust//tools/upstream_wrapper:cargo"
+    ;;
   go)
     # https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md#using-a-go-sdk
     target="@rules_go//go"

--- a/{{ .ProjectSnake }}/tools/cargo
+++ b/{{ .ProjectSnake }}/tools/cargo
@@ -1,0 +1,1 @@
+./_run_under_cwd.sh

--- a/{{ .ProjectSnake }}/tools/format/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/format/BUILD.bazel
@@ -32,5 +32,8 @@ format_multirun(
 {{- if .Computed.python }}
     python = "@aspect_rules_lint//format:ruff",
 {{- end }}
+{{- if .Computed.rust }}
+    rust = "@rules_rust//tools/rustfmt:upstream_rustfmt",
+{{- end }}
     starlark = "@buildifier_prebuilt//:buildifier",
 )


### PR DESCRIPTION
Goals:
- should be as similar as possible to using Rust outside of Bazel. All non-Bazel tooling should continue to work.
- should be consistent with other languages under Aspect, for example the cargo "repinning" operation ought to appear similar-shaped
