### PR TITLE
feat: generate js_binary for simple package.json scripts

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -70,6 +70,7 @@ features:
       - "*/.npmrc"
       - "**/packages/**"
       - "*/tools/pnpm"
+      - "*/.aspect/cli/package-json*.star"
   - value: "{{ .Computed.python }}"
     globs:
       - "*/requirements/**"

--- a/{{ .ProjectSnake }}/.aspect/cli/config.yaml
+++ b/{{ .ProjectSnake }}/.aspect/cli/config.yaml
@@ -12,6 +12,10 @@ configure:
 {{- if .Computed.python }}
     python: true
 {{- end }}
+  plugins:
+{{- if .Computed.javascript }}
+    - .aspect/cli/package-json-scripts.star
+{{- end }}
 
 {{- if .Scaffold.lint }}
 lint:

--- a/{{ .ProjectSnake }}/.aspect/cli/package-json-scripts.star
+++ b/{{ .ProjectSnake }}/.aspect/cli/package-json-scripts.star
@@ -17,7 +17,8 @@ def declare_targets(ctx):
                     kind = "js_binary",
                     attrs = {
                         "entry_point": cmd_parts[-1],
-                    }
+                        "deps": [aspect.Label(name = ":node_modules")],
+                    },
                 )
             else:
                 print("package-json-scripts.star: unable to generate target for {} because command is not a recognized form: {}".format(script, cmd))

--- a/{{ .ProjectSnake }}/.aspect/cli/package-json-scripts.star
+++ b/{{ .ProjectSnake }}/.aspect/cli/package-json-scripts.star
@@ -1,0 +1,34 @@
+aspect.register_rule_kind("js_binary", {
+    "From": "@aspect_rules_js//js:defs.bzl",
+})
+
+def declare_targets(ctx):
+    for file in ctx.sources:
+        if not file.query_results["scripts"][0]:
+            continue
+        for (script, cmd) in file.query_results["scripts"][0].items():
+            # Heuristics to try to understand the structure of a random npm script
+            cmd_parts = cmd.split(" ")
+
+            # Looks like it just directly runs an entry point script
+            if cmd_parts[0] == "node" and len(cmd_parts) == 2:
+                ctx.targets.add(
+                    name = script,
+                    kind = "js_binary",
+                    attrs = {
+                        "entry_point": cmd_parts[-1],
+                    }
+                )
+            else:
+                print("package-json-scripts.star: unable to generate target for {} because command is not a recognized form: {}".format(script, cmd))
+
+aspect.register_configure_extension(
+    id = "package-json-scripts",
+    prepare = lambda cfg: aspect.PrepareResult(
+        sources = [aspect.SourceFiles("package.json")],
+        queries = {
+            "scripts": aspect.JsonQuery(query = ".scripts?"),
+        },
+    ),
+    declare = declare_targets,
+)

--- a/{{ .ProjectSnake }}/.bazeliskrc
+++ b/{{ .ProjectSnake }}/.bazeliskrc
@@ -1,2 +1,2 @@
-BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.10.1
+BAZELISK_BASE_URL=https://static.aspect.build/aspect
+USE_BAZEL_VERSION=aspect/2024.34.43


### PR DESCRIPTION
Requires changing the scaffolded project to use the "pro" version of CLI so we can use starzelle plugins.