### PR TITLE
fix: always expose pyproject.toml

### DIFF
--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -26,7 +26,10 @@ exports_files(
 {{- end }}
 {{- if .Computed.python }}
 
-exports_files(["pyproject.toml"], visibility = ["//:__subpackages__"])
+exports_files(
+    ["pyproject.toml"],
+    visibility = ["//:__subpackages__"],
+)
 {{- end }}
 {{- if .Computed.javascript }}
 

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -26,7 +26,7 @@ exports_files(
 {{- end }}
 {{- if .Computed.python }}
 
-exports_files("pyproject.toml", visibility = ["//:__subpackages__"])
+exports_files(["pyproject.toml"], visibility = ["//:__subpackages__"])
 {{- end }}
 {{- if .Computed.javascript }}
 

--- a/{{ .ProjectSnake }}/BUILD.bazel
+++ b/{{ .ProjectSnake }}/BUILD.bazel
@@ -20,12 +20,13 @@ alias(
 exports_files(
     [
         ".shellcheckrc",
-{{- if .Computed.python }}
-        "pyproject.toml",
-{{- end }}
     ],
     visibility = ["//:__subpackages__"],
 )
+{{- end }}
+{{- if .Computed.python }}
+
+exports_files("pyproject.toml", visibility = ["//:__subpackages__"])
 {{- end }}
 {{- if .Computed.javascript }}
 


### PR DESCRIPTION
shouldn't be conditional on enabling lint
