### PR TITLE
chore: follow GH deprecation instruction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
                 git config user.email "noreply@aspect.build"
                 git config user.name "No One"
                 git commit -a -m "initial commit"
-                echo "::set-output name=dir::$PWD"
+                echo "dir=$PWD" >> $GITHUB_OUTPUT
 
             - run: bazel test ...
               working-directory: "${{ steps.scaffold.outputs.dir }}"


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
