### PR TITLE
chore: add name to weekly_tag.yaml GitHub Actions workflow

### DIFF
--- a/{{ .ProjectSnake }}/.github/workflows/weekly_tag.yaml
+++ b/{{ .ProjectSnake }}/.github/workflows/weekly_tag.yaml
@@ -1,6 +1,8 @@
 # Apply a tag to HEAD at the beginning of each week.
 # We can use this to create semver-looking tags for releases like
 # 2020.44.123+abc1234
+name: Weekly Tag
+
 on:
     schedule:
       # Mondays at 5am UTC / midnight EST


### PR DESCRIPTION
If a name isn't set the then GitHub Actions shows the name of the yaml `.github/workflows/weekly_tag.yaml` in the list of workflows. This gives it a nicer name.