### PR TITLE
fix: use correct target syntax in next steps messaging

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -13,9 +13,9 @@ messages:
     3. Try out some commands, such as:
     {{- if .Scaffold.lint }}
       - Format:        `aspect run format`
-      - Lint:          `aspect lint ...`
+      - Lint:          `aspect lint //...`
     {{- end }}
-      - Run all tests: `aspect test ...`
+      - Run all tests: `aspect test //...`
       - Watch mode:    `./tools/ibazel run //my:devserver`
 
     4. Add source code and run `aspect configure` to create 


### PR DESCRIPTION
The next steps message suggests that the user run `...`, but this is not a valid target pattern, and results in an error.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below:

Produce correct target pattern syntax in "Next Steps" help message after project creation.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Run the scaffold manually from source.
