### PR TITLE
feat: ignore node_modules folders

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -67,6 +67,7 @@ features:
       - "**/weekly_tag.yaml"
   - value: "{{ .Computed.javascript }}"
     globs:
+      - "*/REPO.bazel"
       - "*/package.json"
       - "*/pnpm-*.yaml"
       - "*/*.config.cjs*"

--- a/{{ .ProjectSnake }}/REPO.bazel
+++ b/{{ .ProjectSnake }}/REPO.bazel
@@ -1,0 +1,5 @@
+"""Global repository settings.
+
+See https://bazel.build/rules/lib/globals/repo
+"""
+ignore_directories(["**/node_modules"])


### PR DESCRIPTION
Should have been in #268 

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Created a repo and verified Bazel 8 doesn't try to build node_modules