### PR TITLE
feat: add nogo as a simple linting option

### DIFF
--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -45,6 +45,11 @@ use_repo(multitool, "multitool")
 
 #########################
 # Go
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+{{ if .Scaffold.lint }}
+go_sdk.nogo(nogo = "//tools/lint:nogo")
+{{ end }}
+
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 

--- a/{{ .ProjectSnake }}/tools/lint/BUILD.bazel
+++ b/{{ .ProjectSnake }}/tools/lint/BUILD.bazel
@@ -2,32 +2,36 @@
 
 This is in its own package because it has so many loading-time symbols,
 we don't want to trigger eager fetches of these for builds which aren't running linters.
-"""{{ if or .Computed.javascript .Computed.java .Computed.cpp }}
+"""
 
-{{ if .Computed.cpp -}}
+{{ if .Computed.cpp }}
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
-{{ end -}}
-{{ if .Computed.javascript -}}
+{{ end }}
+{{ if .Computed.javascript }}
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
-{{ end -}}
-{{ if .Computed.java -}}
+{{ end }}
+{{ if .Computed.java }}
 load("@rules_java//java:defs.bzl", "java_binary")
 {{ end }}
+{{ if .Computed.go }}
+load("@rules_go//go:def.bzl", "nogo", "TOOLS_NOGO")
+{{ end }}
+
 package(default_visibility = ["//:__subpackages__"])
-{{- if .Computed.javascript }}
 
+{{ if .Computed.javascript }}
 eslint_bin.eslint_binary(name = "eslint")
-{{- end }}
-{{- if .Computed.java }}
+{{ end }}
 
+{{ if .Computed.java }}
 java_binary(
     name = "pmd",
     main_class = "net.sourceforge.pmd.PMD",
     runtime_deps = ["@net_sourceforge_pmd"],
 )
-{{- end }}
-{{- if .Computed.cpp}}
+{{ end }}
 
+{{ if .Computed.cpp}}
 native_binary(
     name = "clang_tidy",
     src = select(
@@ -44,5 +48,12 @@ native_binary(
     ),
     out = "clang_tidy",
 )
-{{- end }}
-{{- end }}
+{{ end }}
+
+{{ if .Computed.go }}
+nogo(
+    name = "nogo",
+    deps = TOOLS_NOGO,
+    visibility = ["//visibility:public"],
+)
+{{ end }}


### PR DESCRIPTION
rules_lint doesn't have any linting for Go yet.
Follows https://github.com/bazel-contrib/rules_go/blob/master/docs/go/core/bzlmod.md#configuring-nogo

Also remove the careful whitespace handling markers in lint/BUILD.bazel since we now run buildifier after scaffolding. This makes the file more readable.
