### PR TITLE
fix: test that OCI containers build

### DIFF
--- a/user_stories/go
+++ b/user_stories/go
@@ -47,3 +47,6 @@ output=$(curl localhost:8080)
 
 # Shutdown server
 kill %1
+
+# Build an OCI container for the target platform
+bazel build //cmd/hello:image.load

--- a/{{ .ProjectSnake }}/MODULE.bazel
+++ b/{{ .ProjectSnake }}/MODULE.bazel
@@ -37,6 +37,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0")
 {{- if .Scaffold.oci }}
 bazel_dep(name = "rules_oci", version = "2.2.0")
 {{- end }}
+bazel_dep(name = "platforms", version = "0.0.10")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//tools:tools.lock.json")


### PR DESCRIPTION
This demonstrates that `platforms` has to be a Bazel module dep.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
