### PR TITLE
rules_shell generator: write load statements

### DIFF
--- a/{{ .ProjectSnake }}/.aspect/cli/shell.star
+++ b/{{ .ProjectSnake }}/.aspect/cli/shell.star
@@ -1,4 +1,13 @@
 "Create sh_* targets for .bash and .sh files"
+aspect.register_rule_kind("sh_binary", {
+    "From": "@rules_shell//shell:sh_binary.bzl",
+})
+aspect.register_rule_kind("sh_library", {
+    "From": "@rules_shell//shell:sh_library.bzl",
+})
+aspect.register_rule_kind("sh_test", {
+    "From": "@rules_shell//shell:sh_test.bzl",
+})
 
 def declare_targets(ctx):
     if not ctx.sources:


### PR DESCRIPTION
As of Bazel 8 it's naughty to use built-ins without loading them.

There's a flag we should opt into to force us to do this.

@jbedard however when I run with this change I get some bad warnings:

```
% bazel configure       
Updating BUILD files for go, javascript, python, aspect-configure
2025/01/16 10:12:16 Duplicate rule kind "sh_binary"
2025/01/16 10:12:16 Duplicate rule kind "sh_library"
2025/01/16 10:12:16 Duplicate rule kind "sh_test"
```

can we fix that?
