### PR TITLE
fix: py_image generation

### DIFF
--- a/{{ .ProjectSnake }}/tools/oci/py3_image.bzl
+++ b/{{ .ProjectSnake }}/tools/oci/py3_image.bzl
@@ -30,7 +30,7 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
         base = base,
         tars = py_image_layer(
             name = name + "_layers",
-            py_binary = binary,
+            binary = binary,
             root = root,
             layer_groups = layer_groups,
         ),


### PR DESCRIPTION
A breaking change landed upstream https://github.com/aspect-build/rules_py/commit/b9a2c70a56d80b767102660644b7ce3e69d42e7f

And we picked it up via renovate.
