### PR TITLE
fix: ignore pycache folder

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -70,7 +70,6 @@ features:
       - "*/.shellcheckrc"
   - value: "{{ .Computed.javascript }}"
     globs:
-      - "*/REPO.bazel"
       - "*/package.json"
       - "*/pnpm-*.yaml"
       - "*/*.config.cjs*"

--- a/{{ .ProjectSnake }}/REPO.bazel
+++ b/{{ .ProjectSnake }}/REPO.bazel
@@ -2,4 +2,12 @@
 
 See https://bazel.build/rules/lib/globals/repo
 """
-ignore_directories(["**/node_modules"])
+ignore_directories([
+    {{- if .Computed.javascript }}
+    "**/node_modules",
+    {{- end }}
+    {{- if .Computed.python }}
+    "**/.pytest_cache",
+    "**/__pycache__",
+    {{- end }}
+])


### PR DESCRIPTION
Otherwise a mix of non-bazel activities in a python project will break `...` expansions

Discovered in updating the Bazel 102 course.

Note, this will now *always* create the `REPO.bazel` file, which I think is actually better since that's not a JS specific file it's a bit surprising when you got one of those in your project.