### PR TITLE
fix: validation for at least one lang

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -23,10 +23,10 @@ messages:
 
 questions:
   - name: langs
+    validate:
+      min: 1
     prompt:
       multi: true
-      validate:
-        min: 1
       message: Languages to be used in the project
       options:
         - JavaScript & TypeScript


### PR DESCRIPTION
It's supposed to be a sibling of `prompt`
The problem tripped someone in the training course today.