### PR TITLE
chore: test with most recent scaffold version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
             matrix:
                 scaffold-version:
                     - v0.3.0
+                    - v0.6.1
                 preset:
                     - cpp
                     - go


### PR DESCRIPTION
Allows Aspect CLI to upgrade, since we'll have coverage that this template works with both old and new versions.

At some point in the future I'll remove 0.3.0 testing once it "feels" like most users will be on the newer Aspect CLI version.