### PR TITLE
refactor: fully rely on buildifier

### DIFF
--- a/{{ .ProjectSnake }}/.aspect/bazelrc/BUILD
+++ b/{{ .ProjectSnake }}/.aspect/bazelrc/BUILD
@@ -9,12 +9,12 @@ write_aspect_bazelrc_presets(
         "convenience",
         "correctness",
         "debug",
-{{- if .Computed.java }}
+{{ if .Computed.java }}
         "java",
-{{- end }}
-{{- if .Computed.javascript }}
+{{ end }}
+{{ if .Computed.javascript }}
         "javascript",
-{{- end }}
+{{ end }}
         "performance",
     ],
 )

--- a/{{ .ProjectSnake }}/BUILD
+++ b/{{ .ProjectSnake }}/BUILD
@@ -1,52 +1,16 @@
 """Targets in the repository root"""
-{{- if or .Computed.javascript .Computed.python }}
-{{ if .Computed.javascript }}
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-{{- end }}
-{{- if .Computed.python }}
-load("@pip//:requirements.bzl", "all_whl_requirements")
-load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
-load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
-{{- end }}
-{{- end }}
 
+# We prefer BUILD instead of BUILD.bazel
 # gazelle:build_file_name BUILD
 
 {{ if .Computed.javascript }}
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
 # TODO: remove once https://github.com/aspect-build/aspect-cli/issues/560 done
 # gazelle:js_npm_package_target_name pkg
-{{- end }}
-
-{{- if .Scaffold.lint }}
-alias(
-    name = "format",
-    actual = "//tools/format",
-)
-{{- end }}
-{{- if .Computed.shell }}
-exports_files(
-    [".shellcheckrc"],
-    visibility = ["//:__subpackages__"],
-)
-{{- end }}
-{{- if .Computed.go }}
-load("@gazelle//:def.bzl", "gazelle")
-
-# gazelle:prefix github.com/example/project
-gazelle(name = "gazelle")
-{{- end }}
-{{- if .Computed.python }}
-
-exports_files(
-    ["pyproject.toml"],
-    visibility = ["//:__subpackages__"],
-)
-{{- end }}
-{{- if .Computed.javascript }}
-
 npm_link_all_packages(name = "node_modules")
-{{- if .Scaffold.lint }}
+{{ if .Scaffold.lint }}
 
 js_library(
     name = "eslintrc",
@@ -64,9 +28,39 @@ js_library(
     deps = [],
     visibility = ["//tools/format:__pkg__"],
 )
-{{- end }}
-{{- end }}
-{{- if .Computed.python }}
+{{ end }}
+{{ end }}
+
+{{ if .Scaffold.lint }}
+alias(
+    name = "format",
+    actual = "//tools/format",
+)
+{{ end }}
+
+{{ if .Computed.shell }}
+exports_files(
+    [".shellcheckrc"],
+    visibility = ["//:__subpackages__"],
+)
+{{ end }}
+
+{{ if .Computed.go }}
+load("@gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/example/project
+gazelle(name = "gazelle")
+{{ end }}
+
+{{ if .Computed.python }}
+load("@pip//:requirements.bzl", "all_whl_requirements")
+load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
+load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
+
+exports_files(
+    ["pyproject.toml"],
+    visibility = ["//:__subpackages__"],
+)
 
 # Set `aspect configure` to produce aspect_rules_py targets rather than rules_python
 # aspect:map_kind py_binary py_binary @aspect_rules_py//py:defs.bzl
@@ -96,4 +90,4 @@ gazelle_python_manifest(
     pip_repository_name = "pip",
 )
 
-{{- end }}
+{{ end }}

--- a/{{ .ProjectSnake }}/tools/BUILD
+++ b/{{ .ProjectSnake }}/tools/BUILD
@@ -12,21 +12,13 @@ included `.envrc` automates this for you.
 """
 
 load("@bazel_env.bzl", "bazel_env")
-{{ if .Computed.javascript }}
-load("@npm//:defs.bzl", "npm_link_all_packages")
-{{ end }}
-{{ if and .Scaffold.codegen .Computed.python }}
-load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
-{{ end  }}
 load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
 
 package(default_visibility = ["//visibility:public"])
 
-{{ if .Computed.go }}
-alias(name = "go", actual = "@rules_go//go")
-{{ end }}
-
 {{ if and .Scaffold.codegen .Computed.python }}
+load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")
+
 py_console_script_binary(
     name = "copier",
     pkg = "@pip//copier",
@@ -34,13 +26,14 @@ py_console_script_binary(
 {{ end }}
 
 {{ if .Computed.javascript }}
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages(name = "node_modules")
+
 {{ if .Scaffold.codegen }}
 load("@npm//tools:yo/package_json.bzl", yo_bin = "bin")
 yo_bin.yo_binary(name = "yo")
 {{ end }}
-
-npm_link_all_packages(name = "node_modules")
-
 {{ end }}
 
 bazel_env(
@@ -87,8 +80,5 @@ bazel_env(
 {{ if .Computed.python }}
         "python": "$(PYTHON3)",
 {{ end }}
-    } | {
-        t: "@multitool//tools/" + t
-        for t in MULTITOOL_TOOLS
-    },
+    } | MULTITOOL_TOOLS,
 )

--- a/{{ .ProjectSnake }}/tools/format/BUILD
+++ b/{{ .ProjectSnake }}/tools/format/BUILD
@@ -5,13 +5,12 @@ we don't want to trigger eager fetches of these for builds that don't want to ru
 """
 
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
-{{- if .Computed.javascript }}
-load("@npm//:prettier/package_json.bzl", prettier = "bin")
-{{- end }}
 
 package(default_visibility = ["//:__subpackages__"])
 
-{{ if .Computed.javascript -}}
+{{ if .Computed.javascript }}
+load("@npm//:prettier/package_json.bzl", prettier = "bin")
+
 prettier.prettier_binary(
     name = "prettier",
     # Allow the binary to be run outside bazel
@@ -28,24 +27,24 @@ prettier.prettier_binary(
         "--log-level=warn",
     ],
 )
+{{ end }}
 
-{{ end -}}
 format_multirun(
     name = "format",
-{{- if .Computed.cpp}}
+{{ if .Computed.cpp}}
     cc = "@llvm_toolchain_llvm//:bin/clang-format",
-{{- end }}
-{{- if .Computed.go }}
+{{ end }}
+{{ if .Computed.go }}
     go = "@aspect_rules_lint//format:gofumpt",
-{{- end }}
-{{- if .Computed.javascript }}
+{{ end }}
+{{ if .Computed.javascript }}
     javascript = ":prettier",
-{{- end }}
-{{- if .Computed.python }}
+{{ end }}
+{{ if .Computed.python }}
     python = "@aspect_rules_lint//format:ruff",
-{{- end }}
-{{- if .Computed.rust }}
+{{ end }}
+{{ if .Computed.rust }}
     rust = "@rules_rust//tools/rustfmt:upstream_rustfmt",
-{{- end }}
+{{ end }}
     starlark = "@buildifier_prebuilt//:buildifier",
 )

--- a/{{ .ProjectSnake }}/tools/lint/BUILD
+++ b/{{ .ProjectSnake }}/tools/lint/BUILD
@@ -4,26 +4,17 @@ This is in its own package because it has so many loading-time symbols,
 we don't want to trigger eager fetches of these for builds which aren't running linters.
 """
 
-{{ if .Computed.cpp }}
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
-{{ end }}
-{{ if .Computed.javascript }}
-load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
-{{ end }}
-{{ if .Computed.java }}
-load("@rules_java//java:defs.bzl", "java_binary")
-{{ end }}
-{{ if .Computed.go }}
-load("@rules_go//go:def.bzl", "nogo", "TOOLS_NOGO")
-{{ end }}
-
 package(default_visibility = ["//:__subpackages__"])
 
 {{ if .Computed.javascript }}
+load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
+
 eslint_bin.eslint_binary(name = "eslint")
 {{ end }}
 
 {{ if .Computed.java }}
+load("@rules_java//java:defs.bzl", "java_binary")
+
 java_binary(
     name = "pmd",
     main_class = "net.sourceforge.pmd.PMD",
@@ -32,6 +23,8 @@ java_binary(
 {{ end }}
 
 {{ if .Computed.cpp}}
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
 native_binary(
     name = "clang_tidy",
     src = select(
@@ -51,6 +44,8 @@ native_binary(
 {{ end }}
 
 {{ if .Computed.go }}
+load("@rules_go//go:def.bzl", "nogo", "TOOLS_NOGO")
+
 nogo(
     name = "nogo",
     deps = TOOLS_NOGO,


### PR DESCRIPTION
We can reduce the conditional logic by placing load statements with the use-site of symbols they load. buildifier will re-order the load statements for us.

Also throw out the whitespace-control hyphens, which aren't load-bearing anymore.