### PR TITLE
cleanup: remove run_under_cwd

### DIFF
--- a/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
+++ b/{{ .ProjectSnake }}/tools/_run_under_cwd.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-# See https://blog.aspect.build/run-tools-installed-by-bazel
-target="//tools:$(basename "$0")"
-
-# NB: we don't use 'bazel run' because it may leave behind zombie processes under ibazel
-# shellcheck disable=SC2046
-bazel 2>/dev/null build --build_runfile_links "$target" && \
-  BAZEL_BINDIR=. exec $(bazel 2>/dev/null info execution_root)/$(bazel 2>/dev/null cquery --output=files "$target") "$@"

--- a/{{ .ProjectSnake }}/tools/go
+++ b/{{ .ProjectSnake }}/tools/go
@@ -1,1 +1,0 @@
-./_run_under_cwd.sh


### PR DESCRIPTION
We switched to bazel_env.bzl
