### PR TITLE
refactor: clean up canonical labels

### DIFF
--- a/{{ .ProjectSnake }}/tools/lint/linters.bzl
+++ b/{{ .ProjectSnake }}/tools/lint/linters.bzl
@@ -17,8 +17,8 @@ load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 
 {{ if .Computed.cpp -}}
 clang_tidy = lint_clang_tidy_aspect(
-    binary = "@@//tools/lint:clang_tidy",
-    configs = ["@@//:.clang-tidy"],
+    binary = Label(":clang_tidy"),
+    configs = [Label("//:.clang-tidy")],
     lint_target_headers = True,
     angle_includes_are_system = False,
     verbose = False,
@@ -26,17 +26,17 @@ clang_tidy = lint_clang_tidy_aspect(
 {{ end -}}
 {{ if .Computed.java -}}
 pmd = lint_pmd_aspect(
-    binary = "@@//tools/lint:pmd",
-    rulesets = ["@@//:pmd.xml"],
+    binary = Label(":pmd"),
+    rulesets = [Label("//:pmd.xml")],
 )
 {{ end -}}
 {{ if .Computed.javascript -}}
 eslint = lint_eslint_aspect(
-    binary = "@@//tools/lint:eslint",
+    binary = Label(":eslint"),
     # We trust that eslint will locate the correct configuration file for a given source file.
     # See https://eslint.org/docs/latest/use/configure/configuration-files#cascading-and-hierarchy
     configs = [
-        "@@//:eslintrc",
+        Label("//:eslintrc"),
         # if the repository has nested eslintrc files, they must be added here as well
     ],
 )
@@ -47,7 +47,7 @@ eslint_test = lint_test(aspect = eslint)
 ruff = lint_ruff_aspect(
     binary = "@multitool//tools/ruff",
     configs = [
-        "@@//:pyproject.toml",
+        Label("//:pyproject.toml"),
         # if the repository has nested ruff.toml files, they must be added here as well
     ],
 )
@@ -58,7 +58,7 @@ ruff_test = lint_test(aspect = ruff)
 {{ if .Computed.shell }}
 shellcheck = lint_shellcheck_aspect(
     binary = "@multitool//tools/shellcheck",
-    config = "@@//:.shellcheckrc",
+    config = Label("//:.shellcheckrc"),
 )
 
 shellcheck_test = lint_test(aspect = shellcheck)


### PR DESCRIPTION
These shouldn't be something users need to learn about
