### PR TITLE
chore: cleanup duplication of platforms

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -21,7 +21,7 @@ messages:
       - Watch mode:    `ibazel run //my:devserver`
 
     5. Add source code and run `aspect configure` to create 
-       additional `BUILD.bazel` files.
+       additional `BUILD` files.
     
     🌟 Star Aspect CLI on GitHub: <https://github.com/aspect-build/aspect-cli>
     📢 Stay up to date: <https://www.linkedin.com/company/aspect-build/>
@@ -101,7 +101,7 @@ features:
       - "*/.clang-tidy"
   - value: "{{ .Scaffold.oci }}"
     globs:
-      - "*/tools/oci/BUILD.bazel"
+      - "*/tools/oci/BUILD"
   - value: "{{ and .Scaffold.oci .Computed.python }}"
     globs:
       - "*/.aspect/cli/py3_image.star"

--- a/user_stories/java
+++ b/user_stories/java
@@ -13,7 +13,7 @@ EOF
 
 # We didn't wire up the BUILD file generator for Java yet, so users
 # are forced to write this manually.
->src/BUILD.bazel cat <<EOF
+>src/BUILD cat <<EOF
 java_binary(name="Demo", srcs=["Demo.java"])
 EOF
 

--- a/user_stories/rust
+++ b/user_stories/rust
@@ -11,7 +11,7 @@ EOF
 
 # We don't have any BUILD file generation for Rust yet,
 # so users are forced to create it manually.
-cat >hello_world/BUILD.bazel <<EOF
+cat >hello_world/BUILD <<EOF
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 rust_binary(

--- a/{{ .ProjectSnake }}/tools/oci/BUILD
+++ b/{{ .ProjectSnake }}/tools/oci/BUILD
@@ -1,17 +1,1 @@
-platform(
-    name = "linux_arm64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
-    ],
-    visibility = ["//visibility:public"]
-)
-
-platform(
-    name = "linux_amd64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    visibility = ["//visibility:public"]
-)
+# no targets in this package

--- a/{{ .ProjectSnake }}/tools/oci/py3_image.bzl
+++ b/{{ .ProjectSnake }}/tools/oci/py3_image.bzl
@@ -42,8 +42,8 @@ def py3_image(name, binary, root = "/", layer_groups = {}, env = {}, workdir = N
         name = name,
         srcs = [name + "_image"],
         target_platform = select({
-            "@platforms//cpu:arm64": "//tools/oci:linux_arm64",
-            "@platforms//cpu:x86_64": "//tools/oci:linux_amd64",
+            "@platforms//cpu:arm64": "//tools/platforms:linux_aarch64",
+            "@platforms//cpu:x86_64": "//tools/platforms:linux_x86_64",
         }),
     )
     oci_load(


### PR DESCRIPTION
They may be used outside an OCI context for cross-compile, so shouldn't be conditional on user choosing OCI
