### PR TITLE
chore: remove old Scaffold version from testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ jobs:
         strategy:
             matrix:
                 scaffold-version:
-                    - v0.3.0
                     - v0.6.1
                 preset:
                     - cpp


### PR DESCRIPTION
Hopefully nearly all users have upgraded their Aspect CLI, or if using scaffold directly they upgraded that.
