### PR TITLE
fix: use cargo from upstream_wrapper

### DIFF
--- a/{{ .ProjectSnake }}/tools/BUILD
+++ b/{{ .ProjectSnake }}/tools/BUILD
@@ -60,7 +60,7 @@ bazel_env(
         "buildifier": "@buildifier_prebuilt//:buildifier",
 {{ end }}
 {{ if .Computed.rust }}
-        "cargo": "$(CARGO)",
+        "cargo": "@rules_rust//tools/upstream_wrapper:cargo",
 {{ end }}
 {{ if and .Scaffold.codegen .Computed.python }}
         "copier": ":copier",


### PR DESCRIPTION
Downstreams https://github.com/buildbuddy-io/bazel_env.bzl/pull/58
