### PR TITLE
ignore exit 1 from bazel_env

### DIFF
--- a/{{ .ProjectSnake }}/.devcontainer/devcontainer.json
+++ b/{{ .ProjectSnake }}/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "postCreateCommand": "direnv allow; bazel run tools:bazel_env"
+  "postCreateCommand": "direnv allow; bazel run tools:bazel_env || true"
 }


### PR DESCRIPTION
The non-interactive environment the postCreateCommand runs in doesn't see the direnv install hook

fyi @fmeum