### PR TITLE
chore: switch from pre-commit to githooks

### DIFF
--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -67,7 +67,7 @@ features:
     globs:
       - "*/tools/format/*"
       - "*/tools/lint/*"
-      - "*/.pre-commit-config.yaml"
+      - "*/githooks/*"
   - value: "{{ and .Scaffold.lint .Computed.javascript }}"
     globs:
       - "*/prettier.config.cjs"

--- a/{{ .ProjectSnake }}/.bazelrc
+++ b/{{ .ProjectSnake }}/.bazelrc
@@ -29,6 +29,10 @@ common --@rules_python//python/config_settings:bootstrap_impl=script
 common:release --stamp --workspace_status_command=./tools/workspace_status.sh
 {{ end }}
 
+{{- if .Scaffold.lint }}
+common --workspace_status_command=githooks/check-config.sh
+{{- end }}
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/{{ .ProjectSnake }}/.pre-commit-config.yaml
+++ b/{{ .ProjectSnake }}/.pre-commit-config.yaml
@@ -1,8 +1,0 @@
-repos:
-- repo: local
-  hooks:
-  - id: format
-    name: Format
-    entry: aspect run //tools/format:format
-    language: system
-    types: [text]

--- a/{{ .ProjectSnake }}/README.bazel.md
+++ b/{{ .ProjectSnake }}/README.bazel.md
@@ -10,7 +10,7 @@ The `format` command is provided by the `.envrc` file, and the bazel-env.bzl set
 
 - Run `format` to re-format all files locally.
 - Run `format path/to/file` to re-format a single file.
-- Run `pre-commit install` to auto-format changed files on `git commit`.
+- Run `git config core.hooksPath githooks` to add the formatter pre-commit hook. 
 - For CI verification, setup `format` task, see https://docs.aspect.build/workflows/features/lint#formatting
 
 {{- end -}}

--- a/{{ .ProjectSnake }}/githooks/check-config.sh
+++ b/{{ .ProjectSnake }}/githooks/check-config.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+inside_work_tree=$(git rev-parse --is-inside-work-tree 2>/dev/null)
+
+# Encourage developers to setup githooks
+IFS='' read -r -d '' GITHOOKS_MSG <<"EOF"
+    cat <<EOF
+  It looks like the git config option core.hooksPath is not set.
+  This repository uses hooks stored in githooks/ to run tools such as formatters.
+  You can disable this warning by running:
+
+    echo "common --workspace_status_command=" >> ~/.bazelrc
+
+  To set up the hooks, please run:
+
+    git config core.hooksPath githooks
+EOF
+
+if [ "${inside_work_tree}" = "true" ] && [ "$EUID" -ne 0 ] && [ -z "$(git config core.hooksPath)" ]; then
+    echo >&2 "${GITHOOKS_MSG}"
+fi

--- a/{{ .ProjectSnake }}/githooks/pre-commit
+++ b/{{ .ProjectSnake }}/githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git diff --cached --diff-filter=AM --name-only -z | xargs --null --no-run-if-empty bazel run //:format --


### PR DESCRIPTION
Means we don't have to ask developers to install a third-party python tool

Follows updated docs at https://github.com/aspect-build/rules_lint/blob/main/docs/formatting.md#install-as-a-pre-commit-hook