### PR TITLE
fix: avoid rebuilding the formatter when possible

### DIFF
--- a/{{ .ProjectSnake }}/githooks/pre-commit
+++ b/{{ .ProjectSnake }}/githooks/pre-commit
@@ -3,7 +3,11 @@
 git diff --cached --diff-filter=AM --name-only -z | xargs --null --no-run-if-empty bash -c '
   if [ $# -gt 0 ]; then
     echo "Formatting staged files: $@"
-    bazel run //tools/format -- "$@"
+    if [ -e "bazel-out/bazel_env-opt/bin/tools/bazel_env/bin/format" ]; then
+      bazel-out/bazel_env-opt/bin/tools/bazel_env/bin/format "$@"
+    else
+      bazel run //:format -- "$@"
+    fi
     
     # Check if any of the staged files were modified by the formatter
     if ! git diff --quiet -- "$@"; then


### PR DESCRIPTION
Guarantees a fast turnaround in the critical 'git commit' workflow. We don't want analysis cache discards or fighting over the bazel server lock.