### PR TITLE
Fix in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Scaffold for basic Aspect Workflows project
 
-Create a new project using [scaffold](https://hay-kot.github.io/scaffold/) like so:
+Install [scaffold](https://hay-kot.github.io/scaffold/) like so:
 
 ```shell
 % brew tap hay-kot/scaffold-tap
 % brew install scaffold
 # OR
 % go install github.com/hay-kot/scaffold@latest
-% scaffold new github.com/aspect-build/aspect-workflows-template
+```
+
+And then create a new project like so:
+
+```shell
+% scaffold new https://github.com/aspect-build/aspect-workflows-template
 ```


### PR DESCRIPTION
Following the existing docs, I got:

```shell
› scaffold new github.com/aspect-build/aspect-workflows-template
fatal: failed to resolve path: no matching scaffold
```

It looks like it expects a full URL with protocol. This change adds that, and also splits out `scaffold` installation from `scaffold` invocation, since the existing instructions make it look like the `scaffold` invocation only applies if doing the `go`-based install.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Suggested release notes appear below: no
