### PR TITLE
chore: update vscode default settings

### DIFF
--- a/{{ .ProjectSnake }}/.vscode/settings.json
+++ b/{{ .ProjectSnake }}/.vscode/settings.json
@@ -1,13 +1,16 @@
 {
     "search.exclude": {
-        "bazel-*": true
+        "**/bazel-*": true
     },
     "files.watcherExclude": {
-        "bazel-*/**": true,
+        "**/bazel-*/**": true,
         {{ if .Computed.python }}
         "**/__pycache__/**": true,
         "**/.mypy_cache/**": true,
         {{ end }}
+    },
+    "files.associations": {
+        "*.axl": "starlark"
     },
     "C_Cpp.workspaceParsingPriority": "medium",
     "prettier.prettierPath": "./bazel-out/bazel_env-opt/bin/tools/bazel_env/bin/prettier",


### PR DESCRIPTION
- Associate .axl files with Starlark extension syntax highlighting
- Also exclude all nested `bazel-*` folders from vscode search & watcher
