### PR TITLE
chore(template): bump aspect_rules_lint to 2.7.1; re-enable ruby/kitchen-sink lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,15 +106,10 @@ jobs:
       # Skip lint for presets with no wired rules_lint linter:
       #  - minimal/go/scala: rules_lint ships no linter for the language
       #  - rust: clippy lives in the aspect_rules_lint_rust module, which isn't
-      #    published (no BCR entry / release archive) so it can't be wired from
-      #    a BCR-only template yet. rustfmt formatting still runs (see below).
-      #  - ruby: rules_lint 2.6.0's sarif_parser lacks a rubocop case (fixed in
-      #    2.7.0, not yet on BCR) so `aspect lint` exits 1 despite 0 offenses
-      #  - kitchen-sink: includes rust+ruby, so its single lint pass hits both
-      # Re-enable rust once aspect_rules_lint_rust publishes; ruby/kitchen-sink
-      # once the rubocop sarif fix lands on BCR.
+      #    published to BCR yet, so it can't be wired from a BCR-only template.
+      #    rustfmt formatting still runs (see below). Re-enable once it publishes.
       - name: Lint
-        if: ${{ !contains(fromJSON('["minimal","go","scala","rust","ruby","kitchen-sink"]'), matrix.preset) }}
+        if: ${{ !contains(fromJSON('["minimal","go","scala","rust"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
         run: aspect lint --task-key lint-${{ matrix.preset }} -- //...
 

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -5,10 +5,11 @@ name: Publish starter repos
 # "Use this template" / Fork / clone experience. Runs on release tags and
 # manual dispatch.
 #
-# Auth: a GitHub App installed on the aspect-starters org. The App needs only
-# `Contents: write` for steady-state publishing (the repos already exist and
-# are already flagged as template repositories). Store the App's id and private
-# key as repo secrets:
+# Auth: a GitHub App installed on the aspect-starters org. For steady-state
+# publishing the App needs `Contents: write` (push the rendered tree) AND
+# `Workflows: write` (the rendered tree includes .github/workflows/ci.yaml;
+# GitHub rejects pushing workflow files via an App token that lacks this).
+# Store the App's id and private key as repo secrets:
 #   - secrets.STARTERS_APP_ID
 #   - secrets.STARTERS_APP_PRIVATE_KEY
 # Also requires secrets.ASPECT_API_TOKEN to install the Aspect CLI.

--- a/template/MODULE.bazel
+++ b/template/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "gazelle", version = "0.51.3")
 # NB: 2.7.0's sarif_parser toolchain is missing the linux_amd64 platform key
 # (breaks lint/format on Linux CI: "key sarif_parser-linux_amd64 not found").
 # Stay on 2.6.0 until that's fixed upstream.
-bazel_dep(name = "aspect_rules_lint", version = "2.6.0")
+bazel_dep(name = "aspect_rules_lint", version = "2.7.1")
 # bazel_skylib's native_binary backs //tools/lint's linter wrappers.
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 {% endif %}


### PR DESCRIPTION
## Summary

Bumps `aspect_rules_lint` from 2.6.0 to 2.7.1 (now on BCR) and re-enables lint in CI for the `ruby` and `kitchen-sink` presets. 2.7.1 fixes the `sarif_parser` rubocop case that made `aspect lint` exit 1 on the ruby preset despite zero offenses.

`rust` lint stays skipped: clippy lives in the separate `aspect_rules_lint_rust` module, which is not yet published to BCR, so it can't be wired from a BCR-only template. (rustfmt formatting still runs.)

Also documents the publish-starters GitHub App's `Workflows: write` requirement — the rendered tree now ships `.github/workflows/ci.yaml`, which GitHub refuses to push via an App token lacking that scope.

## Changes are visible to end-users

No — this is a template dependency bump + CI/workflow housekeeping. Generated projects get rules_lint 2.7.1 instead of 2.6.0.

## Suggested release notes

- Template bumped to `aspect_rules_lint` 2.7.1; the Ruby preset's `rubocop` lint now runs cleanly.

## Test plan

- `aspect render-preset --preset ruby` + `aspect lint //...` → ✅ "No findings" on 2.7.1 (was exit 1 on 2.6.0).
- ruby/go presets render + build green.
- CI lint skip-list now skips only `minimal`/`go`/`scala`/`rust` (presets with no wired linter); `ruby` and `kitchen-sink` lint again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
