### PR TITLE
ci: grant contents:write to tag.yaml's release job

### DIFF
--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -18,10 +18,15 @@ name: Publish starter repos
 # `Administration: write`; those steps below are best-effort and are skipped
 # without that permission, since all current repos are already provisioned.)
 on:
+  # Sync on every release tag (see tag.yaml / publish_release.yaml).
   push:
     tags: ["v*"]
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Commit, tag, or branch of this repo to render from (default: this workflow's ref)"
+        type: string
+        default: ""
       dry_run:
         description: "Render + commit locally but do not push"
         type: boolean
@@ -50,7 +55,11 @@ jobs:
           - kitchen-sink
     runs-on: ubuntu-latest
     steps:
+      # On a release-tag push, checkout defaults to that tag. On manual dispatch,
+      # render from the requested ref (or this workflow's ref when unset).
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       # Mint a short-lived token for the aspect-starters org from the GitHub App.
       - uses: actions/create-github-app-token@v2

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,34 @@
+# Publish a GitHub release for a `v<year>.<week>.<patch>` tag.
+#
+# There is nothing to build — the template is plain source that `aspect init`
+# fetches at runtime — so this just creates the release with an auto-generated
+# changelog. `aspect init` resolves the repo's latest release as its default
+# template source, and pushing the `v*` tag also triggers publish-starters.yaml
+# to sync the rendered presets to the aspect-starters org.
+name: Publish Release
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "Release tag (e.g. v2026.24.0)"
+        required: true
+        type: string
+  push:
+    tags:
+      - "v202[0-9].[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
+          # Auto-populate the changelog from merged PRs since the last release.
+          generate_release_notes: true

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,46 @@
+# Tag a new release of the template.
+#
+# Computes a `v<year>.<week>.<patch>` version from the most recent weekly tag
+# (see weekly_tag.yaml) and the commits since it, pushes that tag, and hands off
+# to publish_release.yaml. Doing this in CI avoids releasing with local state.
+name: Tag a Release
+on:
+  # Tag manually through the GitHub UI, e.g. after landing a fix downstream
+  # users are waiting for.
+  workflow_dispatch:
+
+jobs:
+  tag:
+    permissions:
+      contents: write # allow create tag
+    runs-on: ubuntu-latest
+    outputs:
+      new-tag: ${{ steps.push_tag.outputs.new-tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history to find the prior weekly tag with `git describe`.
+          fetch-depth: 0
+      - id: push_tag
+        run: |
+          # major.minor = most recent weekly tag (<year>.<week>); patch = commits
+          # since it. The two --match globs cover single- and double-digit weeks.
+          version=$(git describe --tags --long \
+              --match="2[0-9][0-9][0-9].[1-9]" \
+              --match="2[0-9][0-9][0-9].[1-5][0-9]" | sed -e 's/-/./;s/-g.*//')
+          tag="v${version}"
+          curl --fail --request POST \
+              --url "https://api.github.com/repos/${{ github.repository }}/git/refs" \
+              --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              --data @- << EOF
+          {
+              "ref": "refs/tags/${tag}",
+              "sha": "${{ github.sha }}"
+          }
+          EOF
+          echo "new-tag=${tag}" >> "$GITHUB_OUTPUT"
+  release:
+    needs: tag
+    uses: ./.github/workflows/publish_release.yaml
+    with:
+      tag_name: ${{ needs.tag.outputs.new-tag }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -41,6 +41,10 @@ jobs:
           echo "new-tag=${tag}" >> "$GITHUB_OUTPUT"
   release:
     needs: tag
+    # A reusable-workflow call can't be granted more than the caller's own
+    # permissions, so mirror publish_release.yaml's `contents: write` here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/publish_release.yaml
     with:
       tag_name: ${{ needs.tag.outputs.new-tag }}

--- a/.github/workflows/weekly_tag.yaml
+++ b/.github/workflows/weekly_tag.yaml
@@ -1,0 +1,34 @@
+# Tag HEAD `<iso-year>.<iso-week>` at the start of each week, e.g. 2026.24.
+# `tag.yaml` turns the most recent weekly tag into a `v<year>.<week>.<patch>`
+# release version via `git describe`.
+# Follows https://aspect.build/blog/versioning-releases-from-a-monorepo
+name: Weekly Tag
+on:
+  schedule:
+    # Mondays at 5am UTC / midnight EST
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+# Creating the tag ref requires write access to repo contents.
+permissions:
+  contents: write
+
+jobs:
+  tagger:
+    runs-on: ubuntu-latest
+    steps:
+      # `%G.%-V` = ISO week-year + ISO week, with no leading zero on the week so
+      # the tag matches `git describe --match` globs. ISO week-year (%G), not
+      # calendar year (%Y): e.g. Dec 29, 2025 belongs to ISO week 1 of 2026, so
+      # the tag must be 2026.1, not 2025.1.
+      - name: Tag HEAD with <year>.<week>
+        run: |
+          curl --fail --request POST \
+              --url "https://api.github.com/repos/${{ github.repository }}/git/refs" \
+              --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              --data @- << EOF
+          {
+              "ref": "refs/tags/$(date +%G.%-V)",
+              "sha": "${{ github.sha }}"
+          }
+          EOF


### PR DESCRIPTION
Follow-up to #890. The merged `tag.yaml` fails workflow validation:

```
Error calling workflow '.../publish_release.yaml'. The workflow is requesting
'contents: write', but is only allowed 'contents: read'.
```

A reusable-workflow call can't receive more permissions than the calling job holds. The `release` job that `uses:` `publish_release.yaml` must itself declare `contents: write` (which publish_release needs to create the GitHub release).

## Changes are visible to end-users

No — fixes the release workflow so `Tag a Release` can be dispatched.

## Test plan

- `tag.yaml` + `publish_release.yaml` are valid YAML; the `release` job now grants `contents: write` matching the reusable workflow's declared permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)