### PR TITLE
fix: green up starter-repo CI + make template CI a faithful proxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,33 +42,26 @@ jobs:
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 
-      - name: Render + post-scaffold (repin, format, git init)
+      # Render + post-scaffold EXACTLY as the aspect-starters publish job does
+      # (publish-starters.yaml), so the tree the check steps below see is
+      # byte-for-byte what a published starter ships. The check steps then run
+      # the SAME tasks the stamped CI (template/.github/workflows/ci.yaml) runs
+      # downstream — so a green run here means the starter repos are green too.
+      - name: Render + post-scaffold (repin, normalize)
         run: |
           aspect render-preset --preset='${{ matrix.preset }}' --out="$RUNNER_TEMP/out" --name=my_project
           echo "WS=$RUNNER_TEMP/out" >> "$GITHUB_ENV"
           cd "$RUNNER_TEMP/out"
-          # Post-scaffold, in order (mirrors `aspect init`'s post-scaffold):
-          # 1. repin — the template ships placeholder lockfiles; regenerate them.
+          # repin — the template ships placeholder lockfiles; regenerate them.
           if [ -x ./tools/repin ]; then ./tools/repin; fi
           bazel mod deps --lockfile_mode=update || true
-          # 2. git init FIRST — `aspect format`/`gazelle` need a git working tree
-          #    to enumerate/apply changes (and it matches a real user's repo).
+          # git init FIRST — gazelle/format need a git tree to enumerate + apply.
           git init -q
           git add -A
           git -c user.email=ci@aspect.build -c user.name=CI commit -q -m "rendered ${{ matrix.preset }}"
-          # 3. normalize formatting (jinja rendering leaves stray blank lines /
-          #    non-canonical spacing). buildifier for Starlark; aspect format for
-          #    sources. Done after git init so the formatters can see the files,
-          #    and after repin so regenerated files are covered. Amend the commit
-          #    so the check jobs see a fully-normalized tree.
-          #
-          #    `aspect format` publishes a status check whenever it runs on CI
-          #    (keyed by --task-key, shared with the "Format" gate below so they
-          #    update one check, not two). Run it only for presets that have a
-          #    source formatter — minimal/scala/ruby have none, so `aspect format`
-          #    would fail to build //tools/format and publish a failing check;
-          #    buildifier alone covers their (Starlark-only) trees.
+          # Normalize (buildifier + gazelle + format), mirroring the publish job.
           bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r . || true
+          aspect gazelle --task-key gazelle-${{ matrix.preset }} --check-only=false || true
           case "${{ matrix.preset }}" in
             minimal|scala|ruby) ;;
             *) aspect format --task-key format-${{ matrix.preset }} --scope=all || true ;;
@@ -95,32 +88,44 @@ jobs:
         working-directory: ${{ env.WS }}
         run: aspect test --task-key test-${{ matrix.preset }} -- //...
 
-      # buildifier always runs (Starlark formatting; only needs buildifier_prebuilt).
-      # NB: --scope=all — these tasks run in the rendered project ($WS), but the
-      # task's PR-diff detection would otherwise key off THIS (template) repo's
-      # changed files (the jinja .tmpl sources, which aren't valid Starlark).
+      # The steps below run the SAME tasks the generated project's CI
+      # (template/.github/workflows/ci.yaml) runs, with the same per-preset
+      # gating, so this matrix is a faithful proxy for the starter repos. All
+      # use --scope=all: these run in the rendered project ($WS), but a task's
+      # PR-diff detection would otherwise key off THIS repo's changed files.
+
+      # buildifier always runs (Starlark; only needs buildifier_prebuilt).
       - name: Buildifier
         working-directory: ${{ env.WS }}
         run: aspect buildifier --task-key buildifier-${{ matrix.preset }} --scope=all
 
-      # Skip lint for presets with no wired rules_lint linter:
-      #  - minimal/go/scala: rules_lint ships no linter for the language
-      #  - rust: clippy lives in the aspect_rules_lint_rust module, which isn't
-      #    published to BCR yet, so it can't be wired from a BCR-only template.
-      #    rustfmt formatting still runs (see below). Re-enable once it publishes.
+      # gazelle runs for every preset (the stamped CI always has a gazelle job).
+      - name: Gazelle (no changes expected)
+        working-directory: ${{ env.WS }}
+        run: aspect gazelle --task-key gazelle-check-${{ matrix.preset }}
+
+      # Lint runs only for presets with a wired rules_lint aspect (matches the
+      # stamped CI's lint-job gating and .aspect/config.axl's aspects list).
+      # go/scala have no linter; rust's clippy lives in the unpublished
+      # aspect_rules_lint_rust module.
       - name: Lint
         if: ${{ !contains(fromJSON('["minimal","go","scala","rust"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
         run: aspect lint --task-key lint-${{ matrix.preset }} -- //...
 
-      # `format` runs for every preset with a wired source formatter (rust gets
-      # rustfmt, go gofmt, etc.). Skipped only where none exists: scala/ruby have
-      # no formatter yet, and minimal has no languages (buildifier covers its
-      # Starlark in the step above).
+      # format runs for every preset with a wired source formatter. scala/ruby
+      # have none; minimal has no languages (buildifier covers its Starlark).
       - name: Format (no changes expected)
         if: ${{ !contains(fromJSON('["minimal","scala","ruby"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
         run: aspect format --task-key format-${{ matrix.preset }} --scope=all
+
+      # delivery runs for presets whose stamped CI has a delivery job (oci/stamp).
+      # --track-state=false --mode=always mirrors the stamped delivery job.
+      - name: Delivery
+        if: ${{ contains(fromJSON('["go","kitchen-sink"]'), matrix.preset) }}
+        working-directory: ${{ env.WS }}
+        run: aspect delivery --task-key delivery-${{ matrix.preset }} --track-state=false --mode=always
 
       # Execute the preset's user story — an executable-Markdown tutorial that
       # builds/tests/extends the generated project. Run with `sh` (the ~~~ alias

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -80,20 +80,35 @@ jobs:
           aspect render-preset --preset='${{ matrix.preset }}' --out="$RUNNER_TEMP/out" --name=my_project --license=Apache-2.0
           echo "WS=$RUNNER_TEMP/out" >> "$GITHUB_ENV"
 
-      - name: Repin lockfiles
+      - name: Post-scaffold (repin, normalize formatting, commit)
         working-directory: ${{ env.WS }}
         run: |
+          # Mirror the template repo's own post-scaffold CI step so the published
+          # starter is byte-for-byte what that CI validates — otherwise the
+          # downstream repo's buildifier/gazelle/format jobs fail on the raw
+          # render (jinja block-stripping leaves stray blank lines, etc.).
+          #
+          # repin — the template ships placeholder lockfiles; regenerate them.
           if [ -x ./tools/repin ]; then ./tools/repin || true; fi
-
-      - name: Commit rendered tree
-        working-directory: ${{ env.WS }}
-        run: |
+          bazel mod deps --lockfile_mode=update || true
+          # git init FIRST — gazelle/format need a git tree to enumerate + apply.
           git init -q
           git checkout -q -b main
           git config user.email "marvin@aspect.build"
           git config user.name "Marvin, the Aspect bot"
           git add -A
           git commit -q -m "Generated from aspect-workflows-template ${{ github.ref_name }}"
+          # Normalize: buildifier for Starlark, gazelle for BUILD files, aspect
+          # format for sources (skip presets with no source formatter). --scope=all
+          # since there's no base ref to diff against. Then amend the commit.
+          bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r . || true
+          aspect gazelle --task-key publish-gazelle --check-only=false || true
+          case "${{ matrix.preset }}" in
+            minimal|scala|ruby) ;;
+            *) aspect format --task-key publish-format --scope=all || true ;;
+          esac
+          git add -A
+          git commit -q --amend --no-edit
 
       - name: Ensure template repository (best-effort; needs Administration:write)
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}

--- a/template/.aspect/config.axl
+++ b/template/.aspect/config.axl
@@ -67,15 +67,18 @@ def config(ctx: ConfigContext):
     {% endif %}
     {% if oci %}
 
-    # `aspect delivery` builds + pushes the deliverable targets. Tag deliverables
-    # (e.g. an oci_push) with `deliverable` and the query picks them up.
-    ctx.tasks["delivery"].args.query = "attr(tags, deliverable, //...)"
+    # `aspect delivery` builds + pushes the deliverable targets. Query by rule
+    # kind rather than the `deliverable` tag: rules_oci's oci_push macro leaks
+    # the tag onto a non-runnable `_write_file` companion (`:image_push_write_tags`),
+    # so a tag-based query would try to deliver that too. Matching `oci_push rule`
+    # selects only the runnable push targets.
+    ctx.tasks["delivery"].args.query = 'kind("oci_push rule", //...)'
     {% endif %}
     {% if stamp %}
 
-    # Stamp the release-mode delivery build with version info
-    # (workspace_status.sh) via the `release` bazelrc config. release_bazel_flags
-    # apply only to the actual release build, not the change-detection query.
+    # Stamp the release-mode delivery build via the `release` bazelrc config
+    # (--stamp + workspace_status.sh). Applies only to the actual release build,
+    # not the change-detection query.
     ctx.tasks["delivery"].args.release_bazel_flags = [
         "--config=release",
     ]

--- a/template/.aspect/version.axl
+++ b/template/.aspect/version.axl
@@ -3,4 +3,4 @@
 # CI runner uses the same CLI. Bump it to upgrade.
 #
 # See https://aspect.build/docs/cli/install#pinning-a-version
-version("2026.24.15")
+version("2026.25.8")

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -56,7 +56,10 @@ jobs:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect format --task-key format
 {% endif %}
-{% if lint %}
+{# Only presets with a wired rules_lint aspect get a lint job (matches the
+   aspects list in .aspect/config.axl). go/scala have no linter; rust's clippy
+   lives in the unpublished aspect_rules_lint_rust module. #}
+{% if lint and (shell or javascript or python or cpp or kotlin or java or ruby) %}
 
   lint:
     runs-on: ubuntu-latest

--- a/template/README.bazel.md
+++ b/template/README.bazel.md
@@ -152,8 +152,8 @@ Build with stamping via `aspect build --config=release //...`.
 
 ## Delivering container images
 
-Targets tagged `deliverable` (e.g. the `:image_push` from the `hello/` sample's `go_image`) are
-built and pushed by `aspect delivery`. The deliverable query and release flags are configured in
+`oci_push` targets (e.g. the `:image_push` from the `hello/` sample's `go_image`) are built and
+pushed by `aspect delivery`. The delivery query and release flags are configured in
 `.aspect/config.axl`; point each `oci_push`'s `repository` at your registry (the sample uses the
 anonymous, ephemeral `ttl.sh`).
 

--- a/template/bazel/oci/go_image.bzl
+++ b/template/bazel/oci/go_image.bzl
@@ -38,9 +38,9 @@ def go_image(name, binary, base = "@distroless_base"):
         ],
     )
 
-    # Deliverable: `aspect delivery` builds + pushes targets tagged "deliverable"
-    # (see the query in .aspect/config.axl). ttl.sh is an anonymous, ephemeral
-    # registry — fine for a demo; point `repository` at your real registry.
+    # Deliverable: `aspect delivery` builds + pushes every `oci_push` (its query
+    # matches the rule kind — see .aspect/config.axl). ttl.sh is an anonymous,
+    # ephemeral registry — fine for a demo; point `repository` at your registry.
     oci_push(
         name = name + "_push",
         image = name + "_platform",
@@ -48,5 +48,4 @@ def go_image(name, binary, base = "@distroless_base"):
             "latest",
         ],
         repository = "ttl.sh/" + native.package_name(),
-        tags = ["deliverable"],
     )

--- a/template/bazel/workspace_status.sh
+++ b/template/bazel/workspace_status.sh
@@ -10,10 +10,17 @@ readonly git_commit
 # - patch = commits since the week's tag (1), +build = short commit (201b9a8).
 # The two --match globs cover single- and double-digit week tags (2025.1-2025.59).
 # Follows https://aspect.build/blog/versioning-releases-from-a-monorepo
-monorepo_version=$(
-	git describe --tags --long --match="2[0-9][0-9][0-9].[1-9]" --match="2[0-9][0-9][0-9].[1-5][0-9]" |
-		sed -e 's/-/./;s/-g/+/'
-)
+#
+# Falls back to 0.0.0+<sha> when no weekly tag is reachable (a freshly scaffolded
+# project, or any history without a `<year>.<week>` tag) so stamping/delivery
+# still work — `git describe` would otherwise exit non-zero and fail the build.
+if monorepo_version=$(
+	git describe --tags --long --match="2[0-9][0-9][0-9].[1-9]" --match="2[0-9][0-9][0-9].[1-5][0-9]" 2>/dev/null
+); then
+	monorepo_version=$(sed -e 's/-/./;s/-g/+/' <<<"$monorepo_version")
+else
+	monorepo_version="0.0.0+${git_commit:0:8}"
+fi
 
 # A short variant of the monorepo version that drops the +build metadata. For example, 2025.34.0.
 monorepo_short_version=$(sed 's/+.*//' <<<"$monorepo_version")

--- a/template/hello/go/BUILD.bazel
+++ b/template/hello/go/BUILD.bazel
@@ -3,6 +3,11 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//bazel/oci:go_image.bzl", "go_image")
 {%- endif %}
 
+# This is a curated sample with hand-picked target names (hello/hello_test);
+# gazelle would otherwise add its own go_lib/go/go_test targets here. New code
+# elsewhere is still gazelle-managed (see the user story).
+# gazelle:ignore
+
 go_library(
     name = "hello_lib",
     srcs = ["hello.go"],
@@ -23,8 +28,8 @@ go_test(
 )
 {% if oci %}
 
-# OCI image for the sample binary. `go_image` also defines `:image_push`
-# (tagged "deliverable"), which `aspect delivery` builds + pushes.
+# OCI image for the sample binary. `go_image` also defines the `:image_push`
+# (an `oci_push`), which `aspect delivery` builds + pushes.
 go_image(
     name = "image",
     binary = ":hello",

--- a/template/tools/gazelle/BUILD.bazel
+++ b/template/tools/gazelle/BUILD.bazel
@@ -12,7 +12,10 @@ aspect_gazelle(
         {% if go %}"go",{% endif %}
         {% if javascript %}"js",{% endif %}
         {% if cpp %}"cc",{% endif %}
-        {% if kotlin %}"kotlin",{% endif %}
+        # Kotlin (like Java/Scala) ships hand-written BUILD files — its sample
+        # uses kt_jvm_* + JUnit jars gazelle can't resolve, and the kotlin
+        # extension generates kt_jvm_library targets that collide with the
+        # hand-written ones (incl. //tools/gazelle). So gazelle skips Kotlin.
     ],
     {% if shell or (oci and go) %}
     # Aspect Orion extensions (Starlark BUILD generators) shipped in .aspect/gazelle.


### PR DESCRIPTION
## Summary

The `aspect-starters` repos failed CI after the modernized-template sync. **Root cause: the template repo's own CI didn't run the same tasks as the CI it stamps into projects** — it pre-normalized the render, skipped `gazelle`/`delivery`, and skip-listed `lint`, so it stayed green while the faithful downstream CI went red.

This PR fixes the failure categories **and** closes the CI-parity gap so they can't recur.

## Fixes

- **Publish normalization** (`publish-starters.yaml`) — normalize the render (`buildifier -r .` + `aspect gazelle` + `aspect format`) before publishing, mirroring the template CI's post-scaffold step. Starters now ship a clean tree instead of raw jinja output (stray blank lines, etc.).
- **Lint job gating** (stamped `template/.github/workflows/ci.yaml`) — gate the `lint` job on presets that wire a rules_lint aspect (drop go/scala/rust, which have none), so `aspect lint` no longer errors with *"No lint aspect configured"*.
- **Kotlin gazelle** (`template/tools/gazelle/BUILD.bazel`) — drop the `kotlin` gazelle language. Kotlin ships hand-written BUILDs (like Java/Scala); the extension generated `kt_jvm_library` targets that collided with existing targets (incl. `//tools/gazelle`) and couldn't resolve JUnit.
- **`hello/go` gazelle** — `# gazelle:ignore` the curated sample so gazelle (now run in normalization) doesn't add a duplicate `go_test` next to the hand-picked `hello`/`hello_test` targets.
- **Delivery query** (`template/.aspect/config.axl`) — match `kind("oci_push rule", //...)` instead of the `deliverable` tag: rules_oci's `oci_push` macro leaks the tag onto a non-runnable `_write_file` companion (`:image_push_write_tags`). The now-unused tag is dropped from `go_image`.
- **Delivery release flags** — `--config=release` (single source of truth in `.bazelrc`'s `common:release`), which resolves now that the pinned CLI carries the delivery `--config` rc-expansion fix (aspect-cli#1241, released in 2026.25.8).
- **`workspace_status.sh`** — fall back to `0.0.0+<sha>` when no weekly tag is reachable (a freshly scaffolded project), so `--stamp` builds / `aspect delivery` don't fail with *"BazelWorkspaceStatusAction … exited with status 128"*.
- **CLI pin** → `2026.25.8` (`template/.aspect/version.axl`).

## CI parity (the durable fix)

`/.github/workflows/ci.yaml` now renders + normalizes **exactly as the publish job does**, then runs the **same tasks the stamped CI runs** downstream — adding `gazelle` and `delivery` jobs and aligning lint gating. A green run here implies the starter repos are green. (This parity is what caught the `hello/go` duplicate-`go_test` and the delivery bugs before merge.)

## Changes are visible to end-users

Indirectly — generated projects get correct gazelle/lint/delivery config and pin CLI 2026.25.8; the published `aspect-starters/*` repos go green.

## Test plan

Per-preset renders verified: kotlin gazelle runs without collision; go/kitchen-sink delivery resolves only `:image_push` and `--config=release` expands (confirmed end-to-end via the pinned 2026.25.8 launcher); lint job present only for linter-bearing presets; `workspace_status.sh` succeeds in a tag-less repo. The updated template CI matrix is the faithful end-to-end gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
