### PR TITLE
ci: auto-sync starters on release via explicit dispatch

### DIFF
--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -18,7 +18,9 @@ name: Publish starter repos
 # `Administration: write`; those steps below are best-effort and are skipped
 # without that permission, since all current repos are already provisioned.)
 on:
-  # Sync on every release tag (see tag.yaml / publish_release.yaml).
+  # Releases sync via tag.yaml's `sync-starters` job (an explicit dispatch),
+  # because GitHub suppresses ref events from the GITHUB_TOKEN-pushed release
+  # tag. This `push: tags` trigger is the fallback for a tag pushed by hand.
   push:
     tags: ["v*"]
   workflow_dispatch:

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -3,8 +3,9 @@
 # There is nothing to build — the template is plain source that `aspect init`
 # fetches at runtime — so this just creates the release with an auto-generated
 # changelog. `aspect init` resolves the repo's latest release as its default
-# template source, and pushing the `v*` tag also triggers publish-starters.yaml
-# to sync the rendered presets to the aspect-starters org.
+# template source. The aspect-starters sync is dispatched explicitly by
+# tag.yaml's `sync-starters` job (the tag is pushed with GITHUB_TOKEN, whose
+# ref events GitHub suppresses, so a `push: tags` trigger wouldn't fire).
 name: Publish Release
 
 on:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -48,3 +48,24 @@ jobs:
     uses: ./.github/workflows/publish_release.yaml
     with:
       tag_name: ${{ needs.tag.outputs.new-tag }}
+
+  # Sync the aspect-starters repos from the just-released tag. We dispatch
+  # explicitly rather than relying on publish-starters' `push: tags` trigger:
+  # the tag above is pushed with GITHUB_TOKEN, and GitHub suppresses workflow
+  # events from GITHUB_TOKEN-created refs (loop protection), so that trigger
+  # never fires for our releases.
+  sync-starters:
+    needs: [tag, release]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # dispatch another workflow
+    steps:
+      - name: Dispatch publish-starters
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-starters.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ needs.tag.outputs.new-tag }}" \
+            --field "ref=${{ needs.tag.outputs.new-tag }}" \
+            --field "dry_run=false"


### PR DESCRIPTION
## Summary

The `v2026.25.2` release didn't auto-trigger `publish-starters` (`#890`'s pipeline). Root cause: `tag.yaml` pushes the release tag with `secrets.GITHUB_TOKEN`, and **GitHub suppresses workflow events from refs created by `GITHUB_TOKEN`** (recursive-run protection). So `publish-starters`' `push: tags: ["v*"]` trigger never fires for our releases — the tag push is "silent".

## Fix

Add a `sync-starters` job to `tag.yaml` that runs after `release` and **explicitly dispatches** `publish-starters` on the new tag (`gh workflow run ... --ref <tag> --field ref=<tag> --field dry_run=false`). Explicit dispatch isn't subject to the `GITHUB_TOKEN` ref-event suppression.

The `push: tags` trigger on `publish-starters` stays as a fallback for a manually `git push`ed tag (human-pushed tags do trigger). Comments updated to reflect the real mechanism.

## Changes are visible to end-users

No — release automation. After this, cutting a release auto-syncs the `aspect-starters/*` repos.

## Test plan

- All three workflows are valid YAML.
- Next `Tag a Release` dispatch should chain tag → release → starters sync without manual intervention. (For `v2026.25.2`, the sync is being kicked off manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)