### PR TITLE
fix(template): gazelle:exclude workspace_status.sh

### DIFF
--- a/template/bazel/BUILD.bazel
+++ b/template/bazel/BUILD.bazel
@@ -7,6 +7,11 @@ load("@bazelrc-preset.bzl", "bazelrc_preset")
 
 package(default_visibility = ["//visibility:public"])
 
+# workspace_status.sh is a stamping command (--workspace_status_command), not a
+# runnable target — keep gazelle's shell extension from generating an sh_binary
+# for it.
+# gazelle:exclude workspace_status.sh
+
 # Generates bazel/preset.bazelrc (imported by //.bazelrc). Regenerate with
 # `bazel run //bazel:preset.update`.
 bazelrc_preset(


### PR DESCRIPTION
## Summary

On shell-enabled presets (shell, kitchen-sink), `aspect gazelle` produced a diff on `bazel/BUILD.bazel`: the shell gazelle extension wants to generate an `sh_binary` for `bazel/workspace_status.sh`.

That's wrong on two counts:
1. The generated name is **mangled** — `workspace_statu` (a gazelle shell-extension name-derivation bug).
2. More fundamentally, `workspace_status.sh` is a **stamping command** (`--workspace_status_command=./bazel/workspace_status.sh`), not a runnable target — it should never become an `sh_binary`.

## Fix

Add `# gazelle:exclude workspace_status.sh` to `template/bazel/BUILD.bazel` so gazelle leaves that file alone (scoped to the one file, not the whole `bazel/` dir).

## Changes are visible to end-users

No — fixes a spurious gazelle diff in generated shell/kitchen-sink projects.

## Test plan

- Rendered kitchen-sink, ran the CI normalization (buildifier + `aspect gazelle --check-only=false`), then `aspect gazelle` (check): **"All BUILD files are up to date"**, and `bazel/BUILD.bazel` has no `sh_binary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)