### PR TITLE
feat(template): wire Rust clippy via published aspect_rules_lint_rust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,10 +106,9 @@ jobs:
 
       # Lint runs only for presets with a wired rules_lint aspect (matches the
       # stamped CI's lint-job gating and .aspect/config.axl's aspects list).
-      # go/scala have no linter; rust's clippy lives in the unpublished
-      # aspect_rules_lint_rust module.
+      # go/scala have no linter; rust lints via clippy (aspect_rules_lint_rust).
       - name: Lint
-        if: ${{ !contains(fromJSON('["minimal","go","scala","rust"]'), matrix.preset) }}
+        if: ${{ !contains(fromJSON('["minimal","go","scala"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
         run: aspect lint --task-key lint-${{ matrix.preset }} -- //...
 

--- a/template/.aspect/config.axl
+++ b/template/.aspect/config.axl
@@ -46,14 +46,14 @@ def config(ctx: ConfigContext):
 
     # Register the buildifier alias as a real CLI command (`aspect buildifier`).
     ctx.tasks.add(buildifier)
-    {% if lint and (shell or javascript or python or cpp or kotlin or java or ruby) %}
+    {% if lint and (shell or javascript or python or cpp or kotlin or java or ruby or rust) %}
 
     # Wire the built-in `aspect lint` task to the rules_lint aspects for the
     # languages enabled in this project.
     #
     # Only languages with a wired rules_lint linter appear here. go/scala have
-    # none; rust's clippy lives in the unpublished aspect_rules_lint_rust module
-    # (formatting via rustfmt still works through the `format` task).
+    # none; rust's clippy aspect comes from aspect_rules_lint_rust (rustfmt
+    # formatting additionally runs through the `format` task).
     ctx.tasks["lint"].args.aspects = [
         {% if shell %}"//tools/lint:linters.bzl%shellcheck",{% endif %}
         {% if javascript %}"//tools/lint:linters.bzl%eslint",{% endif %}
@@ -63,6 +63,7 @@ def config(ctx: ConfigContext):
         {% if kotlin %}"//tools/lint:linters.bzl%ktlint",{% endif %}
         {% if java %}"//tools/lint:linters.bzl%pmd",{% endif %}
         {% if ruby %}"//tools/lint:linters.bzl%rubocop",{% endif %}
+        {% if rust %}"//tools/lint:linters.bzl%clippy",{% endif %}
     ]
     {% endif %}
     {% if oci %}

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -57,9 +57,8 @@ jobs:
       - run: aspect format --task-key format
 {% endif %}
 {# Only presets with a wired rules_lint aspect get a lint job (matches the
-   aspects list in .aspect/config.axl). go/scala have no linter; rust's clippy
-   lives in the unpublished aspect_rules_lint_rust module. #}
-{% if lint and (shell or javascript or python or cpp or kotlin or java or ruby) %}
+   aspects list in .aspect/config.axl). go/scala have no linter. #}
+{% if lint and (shell or javascript or python or cpp or kotlin or java or ruby or rust) %}
 
   lint:
     runs-on: ubuntu-latest

--- a/template/BUILD.bazel
+++ b/template/BUILD.bazel
@@ -46,6 +46,9 @@ exports_files([
 {% if shell %}
     ".shellcheckrc",
 {% endif %}
+{% if rust %}
+    ".clippy.toml",
+{% endif %}
 ], visibility = ["//:__subpackages__"])
 {% endif %}
 {% if go %}

--- a/template/MODULE.bazel
+++ b/template/MODULE.bazel
@@ -62,6 +62,11 @@ bazel_dep(name = "aspect_rules_py", version = "2.0.0-alpha.3")
 {% endif %}
 {% if cpp %}
 bazel_dep(name = "rules_cc", version = "0.2.19")
+{% endif %}
+{% if cpp or (rust and lint) %}
+# Hermetic C++ toolchain. Also needed by rust+lint: it links rules_rust's
+# process_wrapper, overriding the broken minimal LLVM aspect_rules_lint_rust
+# registers (see the llvm.toolchain() block below).
 bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 {% endif %}
 {% if rust %}
@@ -69,6 +74,11 @@ bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 # AND generates the @rules_rust repo (rules + toolchains) via its rules_rust
 # facade extension below. No direct rules_rust bazel_dep needed.
 bazel_dep(name = "rules_rs", version = "0.0.90")
+{% if lint %}
+# Clippy lint aspect for rust_{binary,library,test}; reads clippy from the
+# configured Rust toolchain. Wired into `aspect lint` via //tools/lint.
+bazel_dep(name = "aspect_rules_lint_rust", version = "0.0.2")
+{% endif %}
 {% endif %}
 {% if ruby %}
 bazel_dep(name = "rules_ruby", version = "0.27.0")
@@ -173,10 +183,14 @@ use_repo(uv, "pypi")
 
 register_toolchains("@uv//:all")
 {% endif %}
-{% if cpp %}
+{% if cpp or (rust and lint) %}
 
 #########################
 # Hermetic C++ toolchain, to relieve the dependency on a locally installed CC etc.
+# Also required by the rust+lint preset: aspect_rules_lint_rust registers a
+# minimal LLVM C++ toolchain (@llvm//toolchain:all) that can't link rules_rust's
+# process_wrapper on Linux ("unable to find library -lgcc_s"). Registering this
+# fuller toolchain from the root module takes priority and fixes that link.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     # NB: llvm doesn't release for all platforms on every patch release
@@ -189,6 +203,8 @@ llvm.toolchain(
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain//:all")
+{% endif %}
+{% if cpp %}
 
 # bazel run @hedron_compile_commands//:refresh_all
 bazel_dep(name = "hedron_compile_commands")
@@ -210,7 +226,15 @@ use_repo(rules_rust, "rules_rust")
 toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")
 toolchains.toolchain(
     edition = "2021",
+{% if lint %}
+    # Must match aspect_rules_lint_rust's pinned toolchain version: both
+    # contribute a `toolchains.toolchain()` tag to the same
+    # `default_rust_toolchains` repo, and rules_rs fails the build on a version
+    # mismatch ("conflicting tag configurations").
+    version = "1.92.0",
+{% else %}
     version = "1.90.0",
+{% endif %}
 )
 use_repo(toolchains, "default_rust_toolchains")
 

--- a/template/tools/lint/linters.bzl
+++ b/template/tools/lint/linters.bzl
@@ -23,6 +23,9 @@ load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
 {% if ruby %}
 load("@aspect_rules_lint//lint:rubocop.bzl", "lint_rubocop_aspect")
 {% endif %}
+{% if rust %}
+load("@aspect_rules_lint_rust//:clippy.bzl", "lint_clippy_aspect")
+{% endif %}
 
 {% if cpp %}
 clang_tidy = lint_clang_tidy_aspect(
@@ -88,5 +91,14 @@ shellcheck_test = lint_test(aspect = shellcheck)
 rubocop = lint_rubocop_aspect(
     binary = Label("@bundle//bin:rubocop"),
     configs = [Label("//:.rubocop.yml")],
+)
+{% endif %}
+{% if rust %}
+# Clippy reads its binary from the configured Rust toolchain (no binary= needed).
+# -Dwarnings promotes warnings to errors so they surface as lint violations.
+# Tag a target `noclippy` to exclude it.
+clippy = lint_clippy_aspect(
+    config = Label("//:.clippy.toml"),
+    clippy_flags = ["-Dwarnings"],
 )
 {% endif %}


### PR DESCRIPTION
The Rust clippy lint aspect is now published to the BCR as `aspect_rules_lint_rust` (0.0.2), so the `rust` preset can finally run `aspect lint`. Until now clippy was omitted everywhere — the template carried a "lives in the unpublished module" note and the rust preset only got rustfmt formatting, not linting.

**What changed** (all gated on `rust` [and `lint`]):

- **MODULE.bazel** — add `bazel_dep(name = "aspect_rules_lint_rust", version = "0.0.2")` for rust+lint. Bump the `rules_rs` Rust toolchain `1.90.0` → `1.92.0` to match the version the lint module pins: both modules contribute a `toolchains.toolchain()` tag to the same `default_rust_toolchains` repo, and `rules_rs` fails the build on a version mismatch (`conflicting tag configurations`).
- **tools/lint/linters.bzl** — load + instantiate `lint_clippy_aspect(config = "//:.clippy.toml", clippy_flags = ["-Dwarnings"])`. The clippy binary comes from the configured Rust toolchain (no `binary=` arg).
- **.aspect/config.axl** — add `rust` to the lint gate and register the clippy aspect in the `aspect lint` aspects list.
- **BUILD.bazel** — `exports_files([".clippy.toml"])` so the aspect's `//:.clippy.toml` label resolves.
- **CI** — add `rust` to the generated project's lint-job gate (`template/.github/workflows/ci.yaml`) and stop excluding `rust` from the template repo's lint matrix leg (`.github/workflows/ci.yaml`), so the matrix actually exercises clippy.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (updated the stale "unpublished module" comments in the template + CI)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes**

- The `rust` preset now runs clippy via `aspect lint`, using the newly-published `aspect_rules_lint_rust` BCR module. The Rust toolchain is bumped to 1.92.0 to match.

### Test plan

- Manual testing: rendered the `rust` preset (`aspect render-preset --preset=rust`), then ran `aspect build //...`, `aspect test //...`, and `aspect lint //...` — all green, clippy reports "No findings" on the clean template. Injected a `clippy::len_zero` violation and confirmed `aspect lint` catches it (`🚨 clippy::len_zero — length comparison to zero`) and fails the task under `-Dwarnings`. (kitchen-sink build on macOS-arm64 hits a pre-existing cpp-LLVM × rules_rust process_wrapper / distroless-arm64 issue unrelated to this change — reproduced on the clean baseline; CI builds it on ubuntu-amd64.)
- Covered by existing test cases: the per-preset CI matrix now runs `aspect lint` for the `rust` leg.
