### PR TITLE
fix(template): language-specific README heading + starter list with CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,22 @@ this template** (or **Fork**), or:
 git clone https://github.com/aspect-starters/<preset>
 ```
 
-Presets: `minimal`, `shell`, `go`, `js`, `py`, `java`, `kotlin`, `cpp`, `rust`,
-`ruby`, `scala`, `kitchen-sink`.
+The **Status** column shows the latest CI run on each starter's `main` branch.
+
+| Repo | Stack | Status |
+| --- | --- | --- |
+| [minimal](https://github.com/aspect-starters/minimal) | An empty, correctly-configured Bazel workspace | [![CI](https://github.com/aspect-starters/minimal/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/minimal/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [go](https://github.com/aspect-starters/go) | Go | [![CI](https://github.com/aspect-starters/go/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/go/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [py](https://github.com/aspect-starters/py) | Python | [![CI](https://github.com/aspect-starters/py/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/py/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [js](https://github.com/aspect-starters/js) | JavaScript & TypeScript | [![CI](https://github.com/aspect-starters/js/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/js/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [java](https://github.com/aspect-starters/java) | Java | [![CI](https://github.com/aspect-starters/java/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/java/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [kotlin](https://github.com/aspect-starters/kotlin) | Kotlin | [![CI](https://github.com/aspect-starters/kotlin/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/kotlin/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [scala](https://github.com/aspect-starters/scala) | Scala | [![CI](https://github.com/aspect-starters/scala/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/scala/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [cpp](https://github.com/aspect-starters/cpp) | C & C++ | [![CI](https://github.com/aspect-starters/cpp/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/cpp/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [rust](https://github.com/aspect-starters/rust) | Rust | [![CI](https://github.com/aspect-starters/rust/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/rust/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [ruby](https://github.com/aspect-starters/ruby) | Ruby | [![CI](https://github.com/aspect-starters/ruby/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/ruby/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [shell](https://github.com/aspect-starters/shell) | Bash / shell | [![CI](https://github.com/aspect-starters/shell/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/shell/actions/workflows/ci.yaml?query=branch%3Amain) |
+| [kitchen-sink](https://github.com/aspect-starters/kitchen-sink) | Everything — all languages + OCI, protobuf, release stamping, codegen | [![CI](https://github.com/aspect-starters/kitchen-sink/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/kitchen-sink/actions/workflows/ci.yaml?query=branch%3Amain) |
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# Aspect Workflows project template
+# Aspect Bazel Starters template
 
-The source of truth for the starter projects scaffolded by **`aspect init`** and
-published as ready-to-use template repositories under
-[github.com/aspect-starters](https://github.com/aspect-starters).
+Ready-to-build [Bazel](https://bazel.build) projects, wired up with the
+[Aspect CLI](https://aspect.build/docs/cli) and best-practice tooling. Pick a
+language, generate a project, and start shipping — no Bazel boilerplate, no
+toolchain yak-shaving.
+
+This repo is the **source of truth** for both paths below: the projects
+[`aspect init`](https://aspect.build/docs/cli) scaffolds and the template
+repositories published under
+[github.com/aspect-starters](https://github.com/aspect-starters) are rendered
+from the one template tree here, so they never drift.
 
 ## Create a new project
 
@@ -45,11 +52,31 @@ The **Status** column shows the latest CI run on each starter's `main` branch.
 | [shell](https://github.com/aspect-starters/shell) | Bash / shell | [![CI](https://github.com/aspect-starters/shell/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/shell/actions/workflows/ci.yaml?query=branch%3Amain) |
 | [kitchen-sink](https://github.com/aspect-starters/kitchen-sink) | Everything — all languages + OCI, protobuf, release stamping, codegen | [![CI](https://github.com/aspect-starters/kitchen-sink/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/aspect-starters/kitchen-sink/actions/workflows/ci.yaml?query=branch%3Amain) |
 
-## Repository layout
+Building a polyglot monorepo? Start from
+[**kitchen-sink**](https://github.com/aspect-starters/kitchen-sink) — every
+language and feature wired together — or run `aspect init --preset kitchen-sink`.
 
-This repo is the editable source of truth for the template. It is rendered by a
-single shared renderer that `aspect init`, this repo's CI, and the
-`aspect-starters` publishing job all use, so they can never drift.
+## What every starter gives you
+
+- 🧱 **Latest Bazel** (bzlmod) with curated flags via [`bazelrc-preset.bzl`](https://github.com/bazel-contrib/bazelrc-preset.bzl)
+- 🧰 **Hermetic dev environment** via [`bazel_env.bzl`](https://github.com/buildbuddy-io/bazel_env.bzl) + [`rules_multitool`](https://github.com/theoremlp/rules_multitool) — tools on your PATH, no manual installs
+- 🎨 **Formatting & linting** built in with [`rules_lint`](https://github.com/aspect-build/rules_lint)
+- 📦 **Native package-manager integration** for the language (pip/uv, pnpm, go.mod, Cargo, Maven, Bundler, …)
+- ⚙️ **Working GitHub Actions CI** that runs `aspect build`/`test`/`lint`/`format` on ephemeral runners — green out of the box
+- 🐳 **OCI containers** via [`rules_oci`](https://github.com/bazel-contrib/rules_oci) (where applicable)
+- 📌 A **pinned Aspect CLI version** (`.aspect/version.axl`) so your whole team and CI use the same tooling
+
+## Contributing
+
+The rest of this README is for maintainers of the template itself. Found a bug
+or want to improve a starter? The starter repos are **generated artifacts** —
+file issues and PRs here, against this repo, not against the `aspect-starters`
+repos.
+
+### Repository layout
+
+One shared renderer drives all three consumers (`aspect init`, this repo's CI,
+and the `aspect-starters` publishing job):
 
 | Path | Purpose |
 | --- | --- |
@@ -59,7 +86,7 @@ single shared renderer that `aspect init`, this repo's CI, and the
 | `dev.axl` | `aspect render-preset` task — renders one preset locally (used by CI + publishing). |
 | `user_stories/` | Executable walkthroughs exercised in CI. |
 
-### Render a preset locally
+#### Render a preset locally
 
 ```shell
 aspect render-preset --preset py --out /tmp/my_project --name my_project
@@ -69,7 +96,7 @@ Conditionals in the template use jinja2 (`{% if python %}` ...) with feature
 flags from the selected preset; the project name is substituted as
 `{{ project_snake }}`.
 
-## Testing
+### Testing
 
 CI renders every preset, regenerates lockfiles, then runs `aspect build`,
 `aspect test`, and (for lint-enabled presets) `aspect lint` / `aspect format`

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,21 @@
-# Bazel workflows
+{%- set ns = namespace(count = 0, label = "") -%}
+{%- if go %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Go" %}{% endif -%}
+{%- if python %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Python" %}{% endif -%}
+{%- if javascript %}{% set ns.count = ns.count + 1 %}{% set ns.label = "JavaScript & TypeScript" %}{% endif -%}
+{%- if java %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Java" %}{% endif -%}
+{%- if kotlin %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Kotlin" %}{% endif -%}
+{%- if scala %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Scala" %}{% endif -%}
+{%- if cpp %}{% set ns.count = ns.count + 1 %}{% set ns.label = "C & C++" %}{% endif -%}
+{%- if rust %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Rust" %}{% endif -%}
+{%- if ruby %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Ruby" %}{% endif -%}
+{%- if shell %}{% set ns.count = ns.count + 1 %}{% set ns.label = "Shell" %}{% endif -%}
+{%- if ns.count == 0 -%}
+# Aspect Bazel Starter
+{%- elif ns.count == 1 -%}
+# Aspect Bazel Starter for {{ ns.label }}
+{%- else -%}
+# Aspect Bazel Polyglot Starter
+{%- endif %}
 
 This repository uses [Aspect Workflows](https://aspect.build) to provide an excellent Bazel developer experience.
 It was generated from the Aspect Workflows template — create your own with `aspect init`


### PR DESCRIPTION
Two README improvements:

**1. Language-specific heading for the generated project README.** The template README opened with a generic `# Bazel workflows`. It now derives a heading from the selected language feature flags:

- **single language** → `# Aspect Bazel Starter for <Language>` (e.g. `for Go`, `for Python`, `for JavaScript & TypeScript`, `for C & C++`)
- **no language** → `# Aspect Bazel Starter` (e.g. the `minimal` preset)
- **multiple languages** → `# Aspect Bazel Polyglot Starter` (e.g. `kitchen-sink`, or any multi-language `aspect init` combo)

Implemented with a minijinja `namespace` counter — this renderer's minijinja build has no `list.append`, which the renderer correctly rejected during testing.

**2. Starter list + CI status badges in this repo's root README.** Replaced the bare preset list with the same starter table used on the [aspect-starters org profile README](https://github.com/aspect-starters/.github/pull/1) (repo, stack, live CI status badge per starter `main`). Intentional duplication — a reader searching for Bazel starters may land on either this repo or the org page, and both should show the full list with health at a glance. The 12 badge URLs are byte-identical between the two.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Generated projects now get a language-specific README heading (e.g. "Aspect Bazel Starter for Go") instead of the generic "Bazel workflows".

### Test plan

- Rendered all 12 presets via `aspect render-preset` and confirmed each heading:
  - `minimal` → `# Aspect Bazel Starter`
  - `go`/`py`/`js`/`java`/`kotlin`/`scala`/`cpp`/`rust`/`ruby`/`shell` → `# Aspect Bazel Starter for <Language>`
  - `kitchen-sink` → `# Aspect Bazel Polyglot Starter`
- Verified no leading blank line and correct spacing below the heading.
- Verified the root README badge URLs match the org profile README exactly (12/12).
