### PR TITLE
fix(template): use linux/arm64/v8 for Go distroless base image

### DIFF
--- a/template/MODULE.bazel
+++ b/template/MODULE.bazel
@@ -384,10 +384,10 @@ oci.pull(
     image = "gcr.io/distroless/base",
     platforms = [
         "linux/amd64",
-        "linux/arm64",
+        "linux/arm64/v8",
     ],
 )
-use_repo(oci, "distroless_base", "distroless_base_linux_amd64", "distroless_base_linux_arm64")
+use_repo(oci, "distroless_base", "distroless_base_linux_amd64", "distroless_base_linux_arm64_v8")
 {% endif %}
 {% if python %}
 oci.pull(


### PR DESCRIPTION
The Go template's OCI base image fails to build locally on Apple Silicon Macs with:

```
No matching manifest found in image gcr.io/distroless/base for platform linux/arm64
```

**Root cause:** The `gcr.io/distroless/base` image index labels its arm64 manifest with `"variant": "v8"`. rules_oci builds its platform-match string from `os/arch/variant`, so the manifest's platform is `linux/arm64/v8`. The Go `oci.pull` requested bare `linux/arm64`, which never matches → `_find_platform_manifest` returns `None` → `fail()`.

CI passed because it runs on `linux/amd64`, which matched fine — only the arm64 fetch path (exercised on Apple Silicon) was broken. The Python base image in the same `MODULE.bazel` already used the variant-qualified form (`linux/arm64/v8` + `..._linux_arm64_v8`); this brings the Go entry in line.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed Go template OCI image builds failing on Apple Silicon Macs (`No matching manifest found ... for platform linux/arm64`) by requesting the variant-qualified `linux/arm64/v8` distroless base manifest.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  1. On an Apple Silicon Mac, generate a project with the Go preset.
  2. `aspect build //...` — previously failed fetching `distroless_base_linux_arm64`; now builds successfully.
