### PR TITLE
ci: add macOS matrix coverage on main pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,10 @@ jobs:
           git -c user.email=ci@aspect.build -c user.name=CI commit -q -m "rendered ${{ matrix.preset }}"
           # Normalize (buildifier + gazelle + format), mirroring the publish job.
           bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r . || true
-          aspect gazelle --task:name gazelle-${{ matrix.preset }}-${{ matrix.os }} --check-only=false || true
+          aspect gazelle --task:name gazelle-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false --check-only=false || true
           case "${{ matrix.preset }}" in
             minimal|scala|ruby) ;;
-            *) aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --scope=all || true ;;
+            *) aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false --scope=all || true ;;
           esac
           git add -A
           git -c user.email=ci@aspect.build -c user.name=CI commit -q --amend --no-edit || true
@@ -110,7 +110,7 @@ jobs:
       # No separate build step: `aspect test` builds everything it needs.
       - name: Test
         working-directory: ${{ env.WS }}
-        run: aspect test --task:name test-${{ matrix.preset }}-${{ matrix.os }} -- //...
+        run: aspect test --task:name test-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false -- //...
 
       # The steps below run the SAME tasks the generated project's CI
       # (template/.github/workflows/ci.yaml) runs, with the same per-preset
@@ -121,12 +121,12 @@ jobs:
       # buildifier always runs (Starlark; only needs buildifier_prebuilt).
       - name: Buildifier
         working-directory: ${{ env.WS }}
-        run: aspect buildifier --task:name buildifier-${{ matrix.preset }}-${{ matrix.os }} --scope=all
+        run: aspect buildifier --task:name buildifier-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false --scope=all
 
       # gazelle runs for every preset (the stamped CI always has a gazelle job).
       - name: Gazelle (no changes expected)
         working-directory: ${{ env.WS }}
-        run: aspect gazelle --task:name gazelle-check-${{ matrix.preset }}-${{ matrix.os }}
+        run: aspect gazelle --task:name gazelle-check-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false
 
       # Lint runs only for presets with a wired rules_lint aspect (matches the
       # stamped CI's lint-job gating and .aspect/config.axl's aspects list).
@@ -141,21 +141,21 @@ jobs:
       - name: Lint
         if: ${{ !contains(fromJSON('["minimal","go","scala"]'), matrix.preset) && !(matrix.os == 'macos-latest' && contains(fromJSON('["cpp","kitchen-sink"]'), matrix.preset)) }}
         working-directory: ${{ env.WS }}
-        run: aspect lint --task:name lint-${{ matrix.preset }}-${{ matrix.os }} -- //...
+        run: aspect lint --task:name lint-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false -- //...
 
       # format runs for every preset with a wired source formatter. scala/ruby
       # have none; minimal has no languages (buildifier covers its Starlark).
       - name: Format (no changes expected)
         if: ${{ !contains(fromJSON('["minimal","scala","ruby"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
-        run: aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --scope=all
+        run: aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false --scope=all
 
       # delivery runs for presets whose stamped CI has a delivery job (oci/stamp).
       # --track-state=false --mode=always mirrors the stamped delivery job.
       - name: Delivery
         if: ${{ contains(fromJSON('["go","kitchen-sink"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
-        run: aspect delivery --task:name delivery-${{ matrix.preset }}-${{ matrix.os }} --track-state=false --mode=always
+        run: aspect delivery --task:name delivery-${{ matrix.preset }}-${{ matrix.os }} --github-status-comments:enabled=false --github-status-checks:enabled=false --track-state=false --mode=always
 
       # Execute the preset's user story — an executable-Markdown tutorial that
       # builds/tests/extends the generated project. Run with `sh` (the ~~~ alias

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,17 @@ concurrency:
 
 permissions:
   id-token: write
+  contents: read
+
+# The aspect-launcher and bazelisk resolve their versions via the GitHub
+# releases API. Unauthenticated that API is capped at 60 req/hr by source IP,
+# which the macOS legs blow through on a cold cache (all presets stampede the
+# API at once on the first-ever macOS run) → "403 API rate limit exceeded".
+# Authenticate those calls with the job token to get the 5000 req/hr limit.
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BAZELISK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   # Render every preset from the local template tree (via the shared renderer the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,10 @@ jobs:
           git -c user.email=ci@aspect.build -c user.name=CI commit -q -m "rendered ${{ matrix.preset }}"
           # Normalize (buildifier + gazelle + format), mirroring the publish job.
           bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r . || true
-          aspect gazelle --task:name gazelle-${{ matrix.preset }} --check-only=false || true
+          aspect gazelle --task:name gazelle-${{ matrix.preset }}-${{ matrix.os }} --check-only=false || true
           case "${{ matrix.preset }}" in
             minimal|scala|ruby) ;;
-            *) aspect format --task:name format-${{ matrix.preset }} --scope=all || true ;;
+            *) aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --scope=all || true ;;
           esac
           git add -A
           git -c user.email=ci@aspect.build -c user.name=CI commit -q --amend --no-edit || true
@@ -110,7 +110,7 @@ jobs:
       # No separate build step: `aspect test` builds everything it needs.
       - name: Test
         working-directory: ${{ env.WS }}
-        run: aspect test --task:name test-${{ matrix.preset }} -- //...
+        run: aspect test --task:name test-${{ matrix.preset }}-${{ matrix.os }} -- //...
 
       # The steps below run the SAME tasks the generated project's CI
       # (template/.github/workflows/ci.yaml) runs, with the same per-preset
@@ -121,12 +121,12 @@ jobs:
       # buildifier always runs (Starlark; only needs buildifier_prebuilt).
       - name: Buildifier
         working-directory: ${{ env.WS }}
-        run: aspect buildifier --task:name buildifier-${{ matrix.preset }} --scope=all
+        run: aspect buildifier --task:name buildifier-${{ matrix.preset }}-${{ matrix.os }} --scope=all
 
       # gazelle runs for every preset (the stamped CI always has a gazelle job).
       - name: Gazelle (no changes expected)
         working-directory: ${{ env.WS }}
-        run: aspect gazelle --task:name gazelle-check-${{ matrix.preset }}
+        run: aspect gazelle --task:name gazelle-check-${{ matrix.preset }}-${{ matrix.os }}
 
       # Lint runs only for presets with a wired rules_lint aspect (matches the
       # stamped CI's lint-job gating and .aspect/config.axl's aspects list).
@@ -134,21 +134,21 @@ jobs:
       - name: Lint
         if: ${{ !contains(fromJSON('["minimal","go","scala"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
-        run: aspect lint --task:name lint-${{ matrix.preset }} -- //...
+        run: aspect lint --task:name lint-${{ matrix.preset }}-${{ matrix.os }} -- //...
 
       # format runs for every preset with a wired source formatter. scala/ruby
       # have none; minimal has no languages (buildifier covers its Starlark).
       - name: Format (no changes expected)
         if: ${{ !contains(fromJSON('["minimal","scala","ruby"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
-        run: aspect format --task:name format-${{ matrix.preset }} --scope=all
+        run: aspect format --task:name format-${{ matrix.preset }}-${{ matrix.os }} --scope=all
 
       # delivery runs for presets whose stamped CI has a delivery job (oci/stamp).
       # --track-state=false --mode=always mirrors the stamped delivery job.
       - name: Delivery
         if: ${{ contains(fromJSON('["go","kitchen-sink"]'), matrix.preset) }}
         working-directory: ${{ env.WS }}
-        run: aspect delivery --task:name delivery-${{ matrix.preset }} --track-state=false --mode=always
+        run: aspect delivery --task:name delivery-${{ matrix.preset }}-${{ matrix.os }} --track-state=false --mode=always
 
       # Execute the preset's user story — an executable-Markdown tutorial that
       # builds/tests/extends the generated project. Run with `sh` (the ~~~ alias

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,8 +131,15 @@ jobs:
       # Lint runs only for presets with a wired rules_lint aspect (matches the
       # stamped CI's lint-job gating and .aspect/config.axl's aspects list).
       # go/scala have no linter; rust lints via clippy (aspect_rules_lint_rust).
+      #
+      # The clang-tidy aspect (cpp, and cpp-in-kitchen-sink) is skipped on macOS:
+      # rules_lint's _update_flag strips absolute `-isystem` paths as if they were
+      # MSVC `/flags`, so the macOS SDK libc++ include is dropped and clang-tidy
+      # can't find <string>/<iostream>. Build/test/format still run on macOS for
+      # cpp. Re-enable once https://github.com/aspect-build/rules_lint/issues/924
+      # ships (PR #779).
       - name: Lint
-        if: ${{ !contains(fromJSON('["minimal","go","scala"]'), matrix.preset) }}
+        if: ${{ !contains(fromJSON('["minimal","go","scala"]'), matrix.preset) && !(matrix.os == 'macos-latest' && contains(fromJSON('["cpp","kitchen-sink"]'), matrix.preset)) }}
         working-directory: ${{ env.WS }}
         run: aspect lint --task:name lint-${{ matrix.preset }}-${{ matrix.os }} -- //...
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,12 @@ jobs:
           - ruby
           - scala
           - kitchen-sink
-    runs-on: ubuntu-latest
+        # macOS runners are billed at 10x Linux on GHA, so only exercise them
+        # on main pushes (where Apple-Silicon-only breakage like the
+        # distroless linux/arm64/v8 manifest bug would otherwise slip through);
+        # PRs stay Linux-only.
+        os: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && fromJSON('["ubuntu-latest","macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
@@ -78,8 +83,16 @@ jobs:
         env:
           ACTIONLINT_VERSION: 1.7.7
         run: |
+          case "$(uname -s)" in
+            Darwin) os=darwin ;;
+            *)      os=linux ;;
+          esac
+          case "$(uname -m)" in
+            arm64|aarch64) arch=arm64 ;;
+            *)             arch=amd64 ;;
+          esac
           curl -fsSL -o actionlint.tar.gz \
-            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${os}_${arch}.tar.gz"
           tar -xzf actionlint.tar.gz actionlint
           ./actionlint -color .github/workflows/*.yaml
 

--- a/template/MODULE.bazel
+++ b/template/MODULE.bazel
@@ -60,8 +60,13 @@ bazel_dep(name = "aspect_rules_swc", version = "2.7.2")
 {% if python %}
 bazel_dep(name = "aspect_rules_py", version = "2.0.0-alpha.3")
 {% endif %}
-{% if cpp %}
-bazel_dep(name = "rules_cc", version = "0.2.19")
+{% if cpp or (rust and lint) %}
+# Pinned to match the LLVM toolchain below (registered for the same condition).
+# toolchains_llvm 1.8.0's generated cc_toolchain selects on the rules_cc target
+# `//cc/toolchains/args/archiver_flags:use_libtool_on_macos_setting`, which
+# rules_cc 0.2.19 renamed away — so 0.2.18 is the newest compatible version.
+# Without this, macOS analysis fails: "no such target ...use_libtool_on_macos_setting".
+bazel_dep(name = "rules_cc", version = "0.2.18")
 {% endif %}
 {% if cpp or (rust and lint) %}
 # Hermetic C++ toolchain. Also needed by rust+lint: it links rules_rust's
@@ -193,11 +198,11 @@ register_toolchains("@uv//:all")
 # fuller toolchain from the root module takes priority and fixes that link.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
-    # NB: llvm doesn't release for all platforms on every patch release
+    # clang 19 — clang 15 can't parse the macOS 15 SDK's libc++ headers
+    # ("unknown type name '__remove_cv'"). 19.1.7 is the last 19.1.x patch that
+    # ships linux-x64 + darwin-arm64 + darwin-x64, so one entry covers all.
     llvm_versions = {
-        "": "15.0.6",
-        "darwin-aarch64": "15.0.7",
-        "darwin-x86_64": "15.0.7",
+        "": "19.1.7",
     },
 )
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")


### PR DESCRIPTION
Adds macOS coverage to the preset CI matrix so Apple-Silicon-only breakage can't slip through a green Linux build — the way the `gcr.io/distroless/base` `linux/arm64/v8` manifest bug (#900) did, breaking `aspect build //...` for Go projects on Macs while CI stayed green.

macOS runners are billed at **10x** Linux on GHA, so the `os` dimension expands to `[ubuntu-latest, macos-latest]` **only on main pushes** and stays `[ubuntu-latest]` on PRs. PR cost is unchanged; only post-merge runs pay for the macOS legs.

Standing up the macOS legs surfaced three real, latent issues this matrix now guards against — two are genuine template fixes that also help anyone building locally on Apple Silicon:

1. **GitHub API rate-limit (CI).** On a cold macOS cache all presets stampede the unauthenticated GitHub releases API the aspect-launcher/bazelisk use (60 req/hr per IP) → `403`. Fixed by authenticating those calls with the job token (`GH_TOKEN`/`GITHUB_TOKEN`/`BAZELISK_GITHUB_TOKEN`) + `contents: read`.
2. **LLVM too old for the macOS 15 SDK (template).** The hermetic toolchain pinned LLVM 15, whose clang can't parse the macOS 15.5 SDK's libc++ (`unknown type name '__remove_cv'`). Bumped to **LLVM 19.1.7** (single entry — 19.1.7 ships linux-x64 + darwin-arm64 + darwin-x64).
3. **rules_cc target rename (template).** `toolchains_llvm` 1.8.0's generated cc_toolchain selects on `//cc/toolchains/args/archiver_flags:use_libtool_on_macos_setting`, which **rules_cc 0.2.19 renamed away**. Pinned rules_cc to **0.2.18** (newest with the target) and widened its gate from `cpp` to `cpp or (rust and lint)` to match where the LLVM toolchain is registered.

Two follow-ups, both scoped out deliberately:
- **clang-tidy lint is skipped on macOS for cpp/kitchen-sink.** This is an unfixed upstream bug — rules_lint's `_update_flag` strips absolute `-isystem` libc++ paths as MSVC `/flags` ([rules_lint#924](https://github.com/aspect-build/rules_lint/issues/924), open PR [#779](https://github.com/aspect-build/rules_lint/pull/779)). Build/test/format still run on macOS for cpp. Re-enable once that ships.
- **Per-task GitHub status comments/checks disabled** (`--github-status-comments:enabled=false --github-status-checks:enabled=false`) on all task calls — ~7 tasks × 12 presets × 2 OSes was tripping the App-installation API limit. The GHA check is the source of truth for the matrix.

The `actionlint` download step is now `uname`-derived (OS + arch) so it works on the macOS arm64 runners.

Scope note: this only touches the template repo's own validation CI (`.github/workflows/ci.yaml`). The stamped CI shipped into generated projects (`template/.github/workflows/ci.yaml`) is unchanged — macOS billing there is the user's call. (The LLVM/rules_cc bumps in #2/#3 *are* in the shipped `template/MODULE.bazel`, since they fix real local builds for users.)

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed the hermetic C++ toolchain on Apple Silicon / macOS 15 SDK: bumped LLVM 15 → 19.1.7 and pinned rules_cc to 0.2.18, so `aspect build //...` works locally for cpp and rust+lint projects on Macs (previously failed with `unknown type name '__remove_cv'` / missing `use_libtool_on_macos_setting`).

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - Verified on macOS 15.5 SDK (Apple Silicon): cpp builds + 2/2 tests pass, rust builds (incl. the C++-backed formatter that previously failed).
  - Full macOS matrix proven green (12/12 presets) on a temporary forced-on run; the gated `os:` expression keeps PRs ubuntu-only and was confirmed to produce 0 macOS / 12 ubuntu legs on this PR.
