### PR TITLE
chore(template): bump aspect-launcher to v2026.26.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,26 @@ jobs:
           git add -A
           git -c user.email=ci@aspect.build -c user.name=CI commit -q --amend --no-edit || true
 
+      # Assert the multitool-pinned aspect-launcher matches the version in
+      # tools.lock.json. The launcher prints `aspect launcher <version>` for
+      # `--version`; we derive the expected version from this repo's lockfile so
+      # the check stays in sync with future bumps. Run the launcher target via
+      # Bazel in the rendered workspace so we exercise the exact pinned binary.
+      - name: Assert aspect-launcher version
+        working-directory: ${{ env.WS }}
+        run: |
+          expected="$(
+            grep -o 'aspect-cli/releases/download/v[^/]*/' "$GITHUB_WORKSPACE/template/tools/tools.lock.json" \
+              | head -n1 | sed -E 's#.*/download/v##; s#/$##'
+          )"
+          echo "Expected launcher version: $expected"
+          actual="$(bazel run @multitool//tools/aspect -- --version)"
+          echo "Actual: $actual"
+          if [ "$actual" != "aspect launcher $expected" ]; then
+            echo "::error::aspect-launcher version mismatch: expected 'aspect launcher $expected', got '$actual'" >&2
+            exit 1
+          fi
+
       # Statically validate the generated GitHub Actions workflow itself
       # (syntax, expressions, permissions). GitHub can't run a rendered workflow
       # as a nested CI run, so actionlint is how we gate the YAML pre-merge; the

--- a/template/tools/tools.lock.json
+++ b/template/tools/tools.lock.json
@@ -4,29 +4,29 @@
     "binaries": [
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.24.15/aspect-launcher-aarch64-unknown-linux-musl",
-        "sha256": "e88803fcea2bd3c3a8b45fd8bbcb74275e540e41152296cb6857bb62a5352751",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.26.25/aspect-launcher-aarch64-unknown-linux-musl",
+        "sha256": "8ceefcc08e00aea9f067d9c0d04d64d89178eeddc1b270833e9e520e74cedb40",
         "os": "linux",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.24.15/aspect-launcher-x86_64-unknown-linux-musl",
-        "sha256": "aacca4f76c45bcc61db63b7b9f59b4255cf14d46d7261845ca906748a365b139",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.26.25/aspect-launcher-x86_64-unknown-linux-musl",
+        "sha256": "b7275b182710761d826696d58d3bd0da9379133751504fbf102b313b5f30c8b1",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.24.15/aspect-launcher-aarch64-apple-darwin",
-        "sha256": "9b3de0436525fb659523cef739337e8e58e441be13e34716467d144c0cdcfb4d",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.26.25/aspect-launcher-aarch64-apple-darwin",
+        "sha256": "e67288870f1c772e11b5a0b05f9ef5415a3c192a9997928f044e835e28e67315",
         "os": "macos",
         "cpu": "arm64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.24.15/aspect-launcher-x86_64-apple-darwin",
-        "sha256": "1d1094cf4a9591a3903f3ac8da29b57a0b6c93f416d5c5b67a46f2463d5a1bb8",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.26.25/aspect-launcher-x86_64-apple-darwin",
+        "sha256": "d30415c87ae07c52b8ed0ed00bcc2d97def32faf40cd2def4a64e1ff350ed61a",
         "os": "macos",
         "cpu": "x86_64"
       }


### PR DESCRIPTION
Bumps the `aspect-launcher` binaries in `template/tools/tools.lock.json` from `v2026.24.15` to the latest release [`v2026.26.25`](https://github.com/aspect-build/aspect-cli/releases/tag/v2026.26.25). All four platform/arch SHA256 checksums were recomputed from the freshly downloaded release binaries.

Also adds a CI assertion to the preset matrix that runs the multitool-pinned launcher (`bazel run @multitool//tools/aspect -- --version`) in the rendered workspace and checks it reports `aspect launcher <version>`, where `<version>` is derived from `tools.lock.json`. This catches any future drift between the lockfile and the binary the launcher actually resolves.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Bump aspect-launcher to v2026.26.25.

### Test plan

- Covered by existing test cases
- New test cases added (CI step asserting `aspect --version` matches the pinned lockfile version)
