### PR TITLE
Bump setup-aspect to v2026.26.7 and pinned Aspect CLI to 2026.26.38

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Aspect CLI
-        uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+        uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Aspect CLI
-        uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+        uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Aspect CLI
-        uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+        uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -72,7 +72,7 @@ jobs:
           owner: aspect-starters
           repositories: ${{ matrix.preset }}
 
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -72,7 +72,7 @@ jobs:
           owner: aspect-starters
           repositories: ${{ matrix.preset }}
 
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -72,7 +72,7 @@ jobs:
           owner: aspect-starters
           repositories: ${{ matrix.preset }}
 
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/template/.aspect/version.axl
+++ b/template/.aspect/version.axl
@@ -3,4 +3,4 @@
 # CI runner uses the same CLI. Bump it to upgrade.
 #
 # See https://aspect.build/docs/cli/install#pinning-a-version
-version("2026.26.34")
+version("2026.26.38")

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect test --task:name test -- //...
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect gazelle --task:name gazelle
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect buildifier --task:name buildifier
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect format --task:name format
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect lint --task:name lint -- //...
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       # Selective delivery (change detection) requires the Aspect Workflows

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect test --task:name test -- //...
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect gazelle --task:name gazelle
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect buildifier --task:name buildifier
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect format --task:name format
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect lint --task:name lint -- //...
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       # Selective delivery (change detection) requires the Aspect Workflows

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect test --task:name test -- //...
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect gazelle --task:name gazelle
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect buildifier --task:name buildifier
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect format --task:name format
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect lint --task:name lint -- //...
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       # Selective delivery (change detection) requires the Aspect Workflows


### PR DESCRIPTION
Update the setup-aspect GitHub Action pins (in the shipped template CI and the
repo's own CI) to v2026.26.7, and bump the template's pinned Aspect CLI version
to 2026.26.38 — the minimum that ships `aspect ci bazelrc`.