### PR TITLE
Bump pinned Aspect CLI to 2026.26.42

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Aspect CLI
-        uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+        uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/publish-starters.yaml
+++ b/.github/workflows/publish-starters.yaml
@@ -72,7 +72,7 @@ jobs:
           owner: aspect-starters
           repositories: ${{ matrix.preset }}
 
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/template/.aspect/version.axl
+++ b/template/.aspect/version.axl
@@ -3,4 +3,4 @@
 # CI runner uses the same CLI. Bump it to upgrade.
 #
 # See https://aspect.build/docs/cli/install#pinning-a-version
-version("2026.26.41")
+version("2026.26.42")

--- a/template/.github/workflows/ci.yaml
+++ b/template/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect test --task:name test -- //...
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect gazelle --task:name gazelle
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect buildifier --task:name buildifier
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect format --task:name format
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       - run: aspect lint --task:name lint -- //...
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ '{{' }} secrets.ASPECT_API_TOKEN {{ '}}' }}
       # Selective delivery (change detection) requires the Aspect Workflows


### PR DESCRIPTION
Bumps the template's pinned Aspect CLI in `template/.aspect/version.axl` from `2026.26.41` to **`2026.26.42`**, which ships the fixed `aspect ci warming`.

## Test plan

- Generated template repos pin the new version.
